### PR TITLE
Handle errors in both Python processor and python code

### DIFF
--- a/logisland-framework/logisland-resources/src/main/resources/conf/python-processing.yml
+++ b/logisland-framework/logisland-resources/src/main/resources/conf/python-processing.yml
@@ -93,18 +93,25 @@ engine:
           type: parser
           documentation: a parser that add a new field if a threshold has been crossed
           configuration:
-            script.code.process: >
+            script.code.process: |
                 outputRecords = []
-
+                # Check that one can read values coming from java:
+                # Go through each record and add a python field with a value from a field coming from java 
                 for record in records:
-                  copyRecord = StandardRecord(record)
-                  # Check that one can read values coming from java
-                  javaFieldValue = copyRecord.getField("bytes_out").asString()
-                  copyRecord.setStringField('python_field', 'loaded bytes_out = ' + javaFieldValue)
+                  try:
+                    copyRecord = StandardRecord(record)
+                    # Get the src_ip field value
+                    javaField = copyRecord.getField("src_ip")
+                    if javaField is not None:
+                      javaFieldValue = javaField.asString()
+                      copyRecord.setStringField('python_field', 'java src_ip = ' + javaFieldValue)
+                  except:
+                    # Print an error message in case of error
+                    errorMsg = 'ERROR in python code processing this record: ' + str(copyRecord)
+                    print errorMsg
+                    copyRecord.addError('unknown_error', errorMsg)
                   outputRecords.append(copyRecord)
-
                 return outputRecords
-
 
         - processor: syslog_debugger
           component: com.hurence.logisland.processor.DebugStream

--- a/logisland-plugins/logisland-scripting-processors-plugin/src/main/java/com/hurence/logisland/processor/scripting/python/PythonProcessor.java
+++ b/logisland-plugins/logisland-scripting-processors-plugin/src/main/java/com/hurence/logisland/processor/scripting/python/PythonProcessor.java
@@ -21,12 +21,14 @@ import com.hurence.logisland.annotation.documentation.Tags;
 import com.hurence.logisland.component.PropertyDescriptor;
 import com.hurence.logisland.processor.*;
 import com.hurence.logisland.record.Record;
+import com.hurence.logisland.record.StandardRecord;
 import com.hurence.logisland.validator.StandardValidators;
 import com.hurence.logisland.validator.ValidationContext;
 import com.hurence.logisland.validator.ValidationResult;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.python.core.PyException;
 import org.python.core.PyInteger;
 import org.python.core.PyObject;
 import org.python.util.PythonInterpreter;
@@ -45,8 +47,7 @@ import static java.util.stream.Collectors.joining;
  * So far identified list of things still to be done:
  * - see TODOs here
  * - init code is always called! Remove this!
- * - inline mode: default imports list
- * - inline mode: user imports  usage, init usage (access context?))
+ * - inline mode: init usage (access context?))
  * - onPropertyModified up to python code (test)
  * - doc for tutorial (inline?, file? , both?)
  */
@@ -492,30 +493,56 @@ public class PythonProcessor extends AbstractProcessor {
 
         Collection<Record> outputRecords = null;
         
-        if (useScriptFile)
+        try {
+        
+            if (useScriptFile)
+            {
+                // File mode
+                 
+                /**
+                 * Call process method of python processor script with the records we received
+                 */
+                pythonInterpreter.set("context", context);
+                pythonInterpreter.set("records", records);
+                pythonInterpreter.exec("outputRecords = pyProcessor.process(context, records)");
+                outputRecords = pythonInterpreter.get("outputRecords", Collection.class);
+            } else
+            {
+                // Inline mode
+    
+                /**
+                 * Call process method of python processor script with the records we received
+                 */
+                pythonInterpreter.set("context", context);
+                pythonInterpreter.set("records", records);
+                pythonInterpreter.exec("outputRecords = process(context, records)");
+                outputRecords = pythonInterpreter.get("outputRecords", Collection.class);
+            }
+        } catch(Throwable t)
         {
-            // File mode
-             
             /**
-             * Call process method of python processor script with the records we received
+             * Error, return an error record
              */
-            pythonInterpreter.set("context", context);
-            pythonInterpreter.set("records", records);
-            pythonInterpreter.exec("outputRecords = pyProcessor.process(context, records)");
-            outputRecords = pythonInterpreter.get("outputRecords", Collection.class);
-        } else
-        {
-            // Inline mode
-
-            /**
-             * Call process method of python processor script with the records we received
-             */
-            pythonInterpreter.set("context", context);
-            pythonInterpreter.set("records", records);
-            pythonInterpreter.exec("outputRecords = process(context, records)");
-            outputRecords = pythonInterpreter.get("outputRecords", Collection.class);
+            String errorMsg = t.getMessage();
+            if (t instanceof PyException)
+            {
+                // Error inside the python code, prepare an error message explaining the error
+                StringBuilder sb = new StringBuilder();
+                PyException pyException = (PyException)t;
+                String errorType = pyException.type.toString();
+                String errorMesage = pyException.value.toString();
+                sb.append("Error in pyhton code:\nType: ").append(errorType);
+                sb.append("\nMessage: ").append(errorMesage);
+                sb.append("\nStack:\n");
+                pyException.traceback.dumpStack(sb);
+                errorMsg = sb.toString();
+            }
+            Record errorRecord = new StandardRecord("error");
+            errorRecord.addError(ProcessError.UNKNOWN_ERROR.getName(), errorMsg);
+            List<Record> errorRecords = new ArrayList<Record>();
+            errorRecords.add(errorRecord);
+            return errorRecords;
         }
-        logger.debug("Processed records ");
 
         return outputRecords;
     }


### PR DESCRIPTION
- Handle exception in python processor when running python code
- Also improved example .yml to also handle exceptions (some input apache logs are not parsable so enter the python code with an error field and some fields not set, that was causing errors)