### PR TITLE
Fix for issue #76 (date parsing problem according to the default Locale)

### DIFF
--- a/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/time/DateUtil.java
+++ b/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/time/DateUtil.java
@@ -447,7 +447,7 @@ public final class DateUtil {
      * @see SimpleDateFormat
      */
     public static Date parse(String dateString, String dateFormat, TimeZone timeZone) throws ParseException {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateFormat);
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateFormat, new Locale("en", "US"));
         simpleDateFormat.setTimeZone(timeZone);
         simpleDateFormat.setLenient(false); // Don't automatically convert invalid date.
         if (dateFormat.equals("MMM dd HH:mm:ss")) {


### PR DESCRIPTION
Fir for https://github.com/Hurence/logisland/issues/76 (SplitTextTest does not pass on some platforms (date parsing problem)).
Simply force US_en locale otherwise for instance on French systems, DateUtilTest and SplitTextTest are failing.