### PR TITLE
Fix for #244. Spark StreamingContext is not serializable and could no…

### DIFF
--- a/logisland-engines/logisland-spark-engine21/src/main/scala/com/hurence/logisland/engine/spark/KafkaStreamProcessingEngine.scala
+++ b/logisland-engines/logisland-spark-engine21/src/main/scala/com/hurence/logisland/engine/spark/KafkaStreamProcessingEngine.scala
@@ -305,7 +305,6 @@ class KafkaStreamProcessingEngine extends AbstractProcessingEngine {
         Collections.unmodifiableList(descriptors)
     }
 
-    private var streamingContext: StreamingContext = null
 
     /**
       * start the engine
@@ -315,7 +314,7 @@ class KafkaStreamProcessingEngine extends AbstractProcessingEngine {
     override def start(engineContext: EngineContext) = {
         logger.info("starting Spark Engine")
         val timeout = engineContext.getPropertyValue(KafkaStreamProcessingEngine.SPARK_STREAMING_TIMEOUT).asInteger().intValue()
-        streamingContext = createStreamingContext(engineContext)
+        val streamingContext = createStreamingContext(engineContext)
 
         /**
           * shutdown context gracefully
@@ -414,8 +413,19 @@ class KafkaStreamProcessingEngine extends AbstractProcessingEngine {
 
     override def shutdown(engineContext: EngineContext) = {
         logger.info(s"shuting down Spark engine")
-        if (streamingContext != null)
-            streamingContext.stop(stopSparkContext = true, stopGracefully = true)
+        engineContext.getStreamContexts.foreach(streamingContext => {
+            try {
+
+                val kafkaStream = streamingContext.getStream.asInstanceOf[KafkaRecordStream]
+                val sc = kafkaStream.getStreamContext();
+                sc.stop(stopSparkContext = true, stopGracefully = true)
+                kafkaStream.stop()
+            } catch {
+                case ex: Exception =>
+                    logger.error("something bad happened, please check Kafka or cluster health : {}", ex.getMessage)
+            }
+
+        })
     }
 
     override def onPropertyModified(descriptor: PropertyDescriptor, oldValue: String, newValue: String) = {

--- a/logisland-engines/logisland-spark-engine21/src/main/scala/com/hurence/logisland/stream/spark/AbstractKafkaRecordStream.scala
+++ b/logisland-engines/logisland-spark-engine21/src/main/scala/com/hurence/logisland/stream/spark/AbstractKafkaRecordStream.scala
@@ -267,7 +267,9 @@ abstract class AbstractKafkaRecordStream extends AbstractRecordStream with Kafka
         SparkUtils.customizeLogLevels
     }
 
-
+    override def getStreamContext() : StreamingContext = {
+        return(this.ssc);
+    }
 
     override def start() = {
         if (ssc == null)

--- a/logisland-engines/logisland-spark-engine21/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStream.scala
+++ b/logisland-engines/logisland-spark-engine21/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStream.scala
@@ -30,4 +30,5 @@ trait KafkaRecordStream extends RecordStream{
       * @param streamContext
       */
     def setup(appName: String,ssc: StreamingContext, streamContext: StreamContext, engineContext: EngineContext);
+    def getStreamContext() : StreamingContext;
 }


### PR DESCRIPTION
…t been passed in a closure

This is the Serialization issue we discuss last week. The shutdown method was using a global variable (Spark StreamingContext) which is not serializable and therefore couldn't be passed in a closure. 
