### PR TITLE
Consolidate session

### DIFF
--- a/logisland-plugins/logisland-consolidate-session-plugin/src/main/java/com/hurence/logisland/processor/consolidateSession/ConsolidateSession.java
+++ b/logisland-plugins/logisland-consolidate-session-plugin/src/main/java/com/hurence/logisland/processor/consolidateSession/ConsolidateSession.java
@@ -353,14 +353,17 @@ public class ConsolidateSession extends AbstractProcessor {
                 // Compute session inactivity duration (in milliseconds)
                 long now = System.currentTimeMillis();
                 long sessionInactivityDuration = (now - latestRecord.getField(timestamp_field).asLong()) / 1000;
-                if (sessionInactivityDuration > session_inactivity_timeout) {
+                if (sessionInactivityDuration > session_inactivity_timeout)
+                {
                     // Mark the session as closed
                     consolidatedSession.setField(isSessionActive_field, FieldType.BOOLEAN, false);
+                    // Max out the sessionInactivityDuration
+                    sessionInactivityDuration = session_inactivity_timeout;
                 } else {
                     consolidatedSession.setField(isSessionActive_field, FieldType.BOOLEAN, true);
                 }
 
-                long sessionDuration = (now - firstRecord.getField(timestamp_field).asLong()) / 1000;
+                long sessionDuration = (latestRecord.getField(timestamp_field).asLong() - firstRecord.getField(timestamp_field).asLong()) / 1000;
                 if (sessionDuration > 0) {
                     consolidatedSession.setField(sessionDuration_field, FieldType.LONG, sessionDuration);
                 }


### PR DESCRIPTION
This PR fixes a bug in the session duration computation as well as it maxes out the session inactivity duration to the configured session timeout