### PR TITLE
Feature/querymatcher w policies

### DIFF
--- a/logisland-api/src/main/java/com/hurence/logisland/validator/StandardValidators.java
+++ b/logisland-api/src/main/java/com/hurence/logisland/validator/StandardValidators.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -451,4 +452,32 @@ public class StandardValidators {
         }
     }
 
+    /**
+     * This class validates a value against an enumeration by checking that the raw value can be transformed to an
+     * item of the enumeration class.
+     *
+     * @param <E> the class of the enumeration to validate.
+     */
+    public static class EnumValidator<E extends Enum<E>> implements Validator {
+        private final Class<E> enumClass;
+
+        public EnumValidator(final Class<E> enumClass) {
+            Objects.requireNonNull(enumClass);
+            this.enumClass = enumClass;
+        }
+
+        @Override
+        public ValidationResult validate(final String subject, final String value) {
+            ValidationResult.Builder builder = new ValidationResult.Builder().subject(subject).input(value);
+            try {
+                Enum.valueOf(this.enumClass, value);
+                builder.valid(true);
+            }
+            catch(final Exception e) {
+                builder.explanation(e.getLocalizedMessage()).valid(false);
+            }
+
+            return builder.build();
+        }
+    }
 }

--- a/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchHandlers.java
+++ b/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchHandlers.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) 2017 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hurence.logisland.processor;
+
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.record.StandardRecord;
+
+import java.util.Collection;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.hurence.logisland.processor.MatchQuery.ALERT_MATCH_NAME;
+import static com.hurence.logisland.processor.MatchQuery.ALERT_MATCH_QUERY;
+
+/**
+ * This class provides various implementations of MatchHandler that handle record match against lucene query.
+ */
+class MatchHandlers {
+
+    private MatchHandlers() {} /* prevent instantiation */
+
+    /**
+     * This interface defines an matchHandler that handles the processing when a query matches. All processed records are
+     * collected internally and should be reclaimed when all query matches have been processed.
+     */
+    interface MatchHandler
+    {
+        /**
+         * Processes a query match.
+         * @param record the record that matched the query.
+         * @param context the context of the processor.
+         * @param matchingRule the name and value of the matched query.
+         */
+        void handleMatch(Record record,
+                         ProcessContext context,
+                         MatchingRule matchingRule);
+
+        /**
+         * Returns the processed records.
+         *
+         * @return the processed records.
+         */
+        Collection<Record> outputRecords();
+    }
+
+    /**
+     * This executors create a new record for each matching query.
+     */
+    static class LegacyMatchHandler
+           implements MatchHandler
+    {
+        // All the processed records.
+        private Collection<Record> outRecords = new ArrayList<>();
+
+        @Override
+        public void handleMatch(final Record record,
+                                final ProcessContext context,
+                                final MatchingRule matchingRule) {
+            this.outRecords.add(
+                    new StandardRecord(record).setType(context.getPropertyValue(MatchQuery.OUTPUT_RECORD_TYPE).asString())
+                                              .setStringField(ALERT_MATCH_NAME, matchingRule.getName())
+                                              .setStringField(ALERT_MATCH_QUERY, matchingRule.getQuery()));
+        }
+
+        @Override
+        public Collection<Record> outputRecords() {
+            return this.outRecords;
+        }
+    }
+
+    /**
+     * This executors concatenate all matching query names and all matching query values as arrays without duplicating
+     * processed records from their identifiers standpoint.
+     */
+    static class ConcatMatchHandler
+           implements MatchHandler
+    {
+        // A map that handles all processed records.
+        private Map<String/*recordIds*/, Record> outRecords = new HashMap<>();
+
+        @Override
+        public void handleMatch(final Record record,
+                                final ProcessContext context,
+                                final MatchingRule matchingRule) {
+            com.hurence.logisland.record.Field nameField = null;
+            com.hurence.logisland.record.Field queryField = null;
+
+            Record outRecord = this.outRecords.get(record.getId());
+
+            if ( outRecord == null ) {
+                // First match. Clone record and set query information.
+                outRecord = new StandardRecord(record).setType(context.getPropertyValue(MatchQuery.OUTPUT_RECORD_TYPE).asString());
+                this.outRecords.put(record.getId(), outRecord);
+
+                // Keep all matched query information.
+                nameField = new com.hurence.logisland.record.Field(ALERT_MATCH_NAME, FieldType.ARRAY, new String[]{matchingRule.getName()});
+                queryField = new com.hurence.logisland.record.Field(ALERT_MATCH_QUERY, FieldType.ARRAY, new String[]{matchingRule.getQuery()});
+            }
+            else {
+                // Append query information to existing one(s).
+                String[] names = (String[])outRecord.getField(ALERT_MATCH_NAME).getRawValue();
+                names = Arrays.copyOf(names, names.length+1);
+                names[names.length-1] = matchingRule.getName();
+                nameField = new com.hurence.logisland.record.Field(ALERT_MATCH_NAME, FieldType.ARRAY, names);
+
+                String[] queries = (String[])outRecord.getField(ALERT_MATCH_QUERY).getRawValue();
+                queries = Arrays.copyOf(queries, queries.length+1);
+                queries[names.length-1] = matchingRule.getQuery();
+                queryField = new com.hurence.logisland.record.Field(ALERT_MATCH_QUERY, FieldType.ARRAY, queries);
+            }
+
+            // Set or update fields.
+            outRecord.setField(nameField);
+            outRecord.setField(queryField);
+        }
+
+        @Override
+        public Collection<Record> outputRecords() {
+            return new ArrayList(this.outRecords.values());
+        }
+    }
+
+    /**
+     * This executors ensures that non-matching records received by the processor are also sent out.
+     */
+    static class AllInAllOutMatchHandler
+           implements MatchHandler
+    {
+        // In case policy is 'forward', records that did not match any document must be sent to output anyway.
+        private final Map<String/*recordIds*/, Record> inputRecords;
+
+        // The inner matchHandler that either keeps the first matching rule information or concatenate all matching rules.
+        private final MatchHandler matchHandler;
+
+        /**
+         *
+         * @param records the records received by the processor.
+         * @param onMatchPolicy the match policy to specify if only the first matching rule or all matching rules
+         *                      are tagged in the send out records.
+         */
+        public AllInAllOutMatchHandler(final Collection<Record> records,
+                                       final MatchQuery.OnMatchPolicy onMatchPolicy) {
+            this.matchHandler = onMatchPolicy== MatchQuery.OnMatchPolicy.first ? new LegacyMatchHandler()
+                                        : new ConcatMatchHandler();
+
+            this.inputRecords = new HashMap<>();
+            // Store all record identifiers.
+            records.forEach(record -> inputRecords.put(record.getId(), record));
+        }
+
+        @Override
+        public void handleMatch(final Record record,
+                                final ProcessContext context,
+                                final MatchingRule matchingRule) {
+            // Forward processing of tagging to either only first or concat matchHandler.
+            this.matchHandler.handleMatch(record, context, matchingRule);
+            // Remove the processed record from the records to append in case of non-match.
+            inputRecords.remove(record.getId());
+        }
+
+        @Override
+        public Collection<Record> outputRecords() {
+            // Get output records from matchHandler...
+            Collection<Record> outRecords = this.matchHandler.outputRecords();
+            // ...and add all records that did not match any query.
+            if (!inputRecords.isEmpty()) {
+                inputRecords.values().forEach(record -> outRecords.add(record));
+            }
+            return outRecords;
+        }
+    }
+}

--- a/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchQuery.java
+++ b/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchQuery.java
@@ -87,11 +87,9 @@ public class MatchQuery extends AbstractProcessor {
             .name("policy.onmatch")
             .description("the policy applied to match events: " +
                          "'" + OnMatchPolicy.first.toString() + "' (default value)" +
-                         "'first' (default value) match events are tagged with the name and value of the first query " +
-                             "that matched;" +
-
+                         " match events are tagged with the name and value of the first query that matched;" +
                          "'" + OnMatchPolicy.all.toString() + "' match events are tagged with all names and values of" +
-                             " the queries that matched;")
+                             " the queries that matched.")
             .required(false)
             .addValidator(new StandardValidators.EnumValidator(OnMatchPolicy.class))
             .defaultValue(OnMatchPolicy.first.toString())

--- a/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchQuery.java
+++ b/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchQuery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2016-2017 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import com.hurence.logisland.annotation.documentation.CapabilityDescription;
 import com.hurence.logisland.annotation.documentation.Tags;
 import com.hurence.logisland.component.PropertyDescriptor;
 import com.hurence.logisland.record.Record;
-import com.hurence.logisland.record.StandardRecord;
 import com.hurence.logisland.validator.StandardValidators;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.StopAnalyzer;
@@ -54,6 +53,8 @@ import java.util.*;
 @DynamicProperty(name = "query", supportsExpressionLanguage = true, value = "some Lucene query", description = "generate a new record when this query is matched")
 public class MatchQuery extends AbstractProcessor {
 
+    public final static String ALERT_MATCH_NAME = "alert_match_name";
+    public final static String ALERT_MATCH_QUERY = "alert_match_query";
 
     public static final PropertyDescriptor NUMERIC_FIELDS = new PropertyDescriptor.Builder()
             .name("numeric.fields")
@@ -70,11 +71,39 @@ public class MatchQuery extends AbstractProcessor {
             .defaultValue("alert_match")
             .build();
 
+    public static final PropertyDescriptor ON_MISS_POLICY = new PropertyDescriptor.Builder()
+            .name("policy.onmiss")
+            .description("the policy applied to miss events: " +
+                         "'" + OnMissPolicy.discard.toString() + "' (default value)" +
+                             " drop events that did not match any query;" +
+                         "'" + OnMissPolicy.forward.toString() + "'" +
+                             " include also events that did not match any query.")
+            .required(false)
+            .addValidator(new StandardValidators.EnumValidator(OnMissPolicy.class))
+            .defaultValue(OnMissPolicy.discard.toString())
+            .build();
+
+    public static final PropertyDescriptor ON_MATCH_POLICY = new PropertyDescriptor.Builder()
+            .name("policy.onmatch")
+            .description("the policy applied to match events: " +
+                         "'" + OnMatchPolicy.first.toString() + "' (default value)" +
+                         "'first' (default value) match events are tagged with the name and value of the first query " +
+                             "that matched;" +
+
+                         "'" + OnMatchPolicy.all.toString() + "' match events are tagged with all names and values of" +
+                             " the queries that matched;")
+            .required(false)
+            .addValidator(new StandardValidators.EnumValidator(OnMatchPolicy.class))
+            .defaultValue(OnMatchPolicy.first.toString())
+            .build();
+
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         final List<PropertyDescriptor> descriptors = new ArrayList<>();
         descriptors.add(NUMERIC_FIELDS);
         descriptors.add(OUTPUT_RECORD_TYPE);
+        descriptors.add(ON_MATCH_POLICY);
+        descriptors.add(ON_MISS_POLICY);
         descriptors.add(AbstractProcessor.INCLUDE_INPUT_RECORDS);
 
         return Collections.unmodifiableList(descriptors);
@@ -93,12 +122,41 @@ public class MatchQuery extends AbstractProcessor {
 
     private static Logger logger = LoggerFactory.getLogger(MatchQuery.class);
 
+    /**
+     * The policy that defines the behaviour when a record matches a query.
+     */
+    enum OnMatchPolicy {
+        /**
+         * Tag the matching records with only the first query name and query value. This is the default value.
+         */
+        first, /* legacy */
+        /**
+         * Tag the matching records with all query names and query values expressed as String arrays.
+         */
+        all
+    }
+
+    /**
+     * The policy that defines the behaviour when a record did not match any query.
+     */
+    enum OnMissPolicy {
+        /**
+         * Discard non-matching records. Only tagged records are sent by this processor. This is the default value.
+         */
+        discard, /* legacy */
+        /**
+         * Forward also records.
+         */
+        forward
+    }
 
     private Monitor monitor;
     private KeywordAnalyzer keywordAnalyzer;
     private StandardAnalyzer standardAnalyzer;
     private StopAnalyzer stopAnalyzer;
     private Map<String, MatchingRule> matchingRules;
+    private OnMissPolicy onMissPolicy;
+    private OnMatchPolicy onMatchPolicy;
 
     @Override
     public void init(final ProcessContext context) {
@@ -108,6 +166,8 @@ public class MatchQuery extends AbstractProcessor {
         standardAnalyzer = new StandardAnalyzer();
         stopAnalyzer = new StopAnalyzer();
         matchingRules = new HashMap<>();
+        onMissPolicy = OnMissPolicy.valueOf(context.getPropertyValue(ON_MISS_POLICY).asString());
+        onMatchPolicy = OnMatchPolicy.valueOf(context.getPropertyValue(ON_MATCH_POLICY).asString());
         NumericQueryParser queryMatcher = new NumericQueryParser("field");
 
 
@@ -155,12 +215,12 @@ public class MatchQuery extends AbstractProcessor {
 
 
         // convert all numeric fields to double to get numeric range working ...
-        List<Record> outRecords = new ArrayList<>();
-        List<InputDocument> inputDocs = new ArrayList<>();
-        Map<String, Record> inputRecords = new HashMap<>();
-        for (Record record : records) {
-            InputDocument.Builder docbuilder = InputDocument.builder(record.getId());
-            for (String fieldName : record.getAllFieldNames()) {
+        final List<Record> outRecords = new ArrayList<>();
+        final List<InputDocument> inputDocs = new ArrayList<>();
+        final Map<String, Record> inputRecords = new HashMap<>();
+        for (final Record record : records) {
+            final InputDocument.Builder docbuilder = InputDocument.builder(record.getId());
+            for (final String fieldName : record.getAllFieldNames()) {
 
                 switch (record.getField(fieldName).getType()) {
                     case STRING:
@@ -188,7 +248,7 @@ public class MatchQuery extends AbstractProcessor {
         }
 
         // match a batch of documents
-        Matches<QueryMatch> matches = null;
+        Matches<QueryMatch> matches;
         try {
             matches = monitor.match(DocumentBatch.of(inputDocs), SimpleMatcher.FACTORY);
         } catch (IOException e) {
@@ -196,22 +256,31 @@ public class MatchQuery extends AbstractProcessor {
             return outRecords;
         }
 
-        String outputRecordType = context.getPropertyValue(OUTPUT_RECORD_TYPE).asString();
+        MatchHandlers.MatchHandler _matchHandler = null;
 
+        if (onMatchPolicy==OnMatchPolicy.first && onMissPolicy==OnMissPolicy.discard) {
+            // Legacy behaviour
+            _matchHandler = new MatchHandlers.LegacyMatchHandler();
+        }
+        else if (onMissPolicy==OnMissPolicy.discard) {
+            // Ignore non matching records. Concat all query information (name, value) instead of first one only.
+            _matchHandler = new MatchHandlers.ConcatMatchHandler();
+        }
+        else {
+            // All records in, all records out. Concat all query information (name, value) instead of first one only.
+            _matchHandler = new MatchHandlers.AllInAllOutMatchHandler(records, this.onMatchPolicy);
+        }
+
+        final MatchHandlers.MatchHandler matchHandler = _matchHandler;
         for (DocumentMatches<QueryMatch> docMatch : matches) {
-            docMatch.getMatches().forEach(queryMatch -> {
-                outRecords.add(
-                        new StandardRecord(inputRecords.get(docMatch.getDocId()))
-                                .setType(outputRecordType)
-                                .setStringField("alert_match_name", queryMatch.getQueryId())
-                                .setStringField("alert_match_query", matchingRules.get(queryMatch.getQueryId()).getQuery())
-                );
-            });
+            docMatch.getMatches().forEach(queryMatch ->
+                matchHandler.handleMatch(inputRecords.get(docMatch.getDocId()),
+                                         context,
+                                         matchingRules.get(queryMatch.getQueryId()))
+            );
 
         }
 
-        return outRecords;
+        return matchHandler.outputRecords();
     }
-
-
 }

--- a/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchingRule.java
+++ b/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchingRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2016-2017 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@ package com.hurence.logisland.processor;
 /**
  * Created by fprunier on 15/04/16.
  */
-public class MatchingRule {
-    private String name = null;
-    private String query = null;
+class MatchingRule {
+    private final String name;
+    private final String query;
 
-    public MatchingRule(String name, String query) {
+
+    public MatchingRule(final String name, final String query) {
         this.name = name;
         this.query = query;
     }

--- a/logisland-plugins/logisland-querymatcher-plugin/src/test/java/com/hurence/logisland/processor/MatchQueryTest.java
+++ b/logisland-plugins/logisland-querymatcher-plugin/src/test/java/com/hurence/logisland/processor/MatchQueryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2016-2017 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,23 @@
 package com.hurence.logisland.processor;
 
 
+import com.hurence.logisland.record.Field;
 import com.hurence.logisland.record.FieldType;
 import com.hurence.logisland.record.Record;
 import com.hurence.logisland.record.StandardRecord;
+import com.hurence.logisland.util.runner.MockRecord;
 import com.hurence.logisland.util.runner.TestRunner;
 import com.hurence.logisland.util.runner.TestRunners;
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 public class MatchQueryTest {
 
-    static String docspath = "data/documents/frenchpress";
-    static String rulespath = "data/rules";
-    static String EXCEPTION_RECORD = "exception_record";
+    private static String EXCEPTION_RECORD = "exception_record";
 
     private static Logger logger = LoggerFactory.getLogger(MatchQueryTest.class);
 
@@ -150,4 +153,284 @@ public class MatchQueryTest {
         testRunner.assertOutputRecordsCount(3);
     }
 
+    /**
+     * A bunch of records for testing purpose.
+     */
+    private static final Record[] RECORDS = {
+            new StandardRecord(EXCEPTION_RECORD)
+                    .setId("id1")
+                    .setStringField("exception", "miss")
+                    .setStringField("message", "miss"),
+            new StandardRecord(EXCEPTION_RECORD)
+                    .setId("id2")
+                    .setStringField("exception", "miss")
+                    .setStringField("message", "match"),
+            new StandardRecord(EXCEPTION_RECORD)
+                    .setId("id3")
+                    .setStringField("exception", "match")
+                    .setStringField("message", "miss"),
+            new StandardRecord(EXCEPTION_RECORD)
+                    .setId("id4")
+                    .setStringField("exception", "match")
+                    .setStringField("message", "match")
+    };
+
+    /**
+     * Legacy behaviour.
+     * Only matching records are not filtered out.
+     * Records that match more than one query are duplicated.
+     */
+    @Test
+    public void validateLegacy() {
+        final TestRunner testRunner = TestRunners.newTestRunner(new MatchQuery());
+        testRunner.setProperty("match_exception", "exception:match");
+        testRunner.setProperty("match_message", "message:match");
+        testRunner.assertValid();
+        testRunner.clearQueues();
+        testRunner.enqueue(RECORDS);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(4);
+
+        List<MockRecord> records = testRunner.getOutputRecords();
+        records.forEach(record -> {
+            final String id = record.getId();
+            final Field field = record.getField(MatchQuery.ALERT_MATCH_NAME);
+            // Records without match should be ignored.
+            Assert.assertNotNull(field);
+
+            final Object _matchName = field.getRawValue();
+            // One match name per record.
+            Assert.assertEquals(_matchName.getClass(),
+                                String.class);
+            final String matchName = (String)_matchName;
+
+            if ("id1".equals(id)) {
+                // No match
+                Assert.fail("Unexpected match for id1");
+            }
+            else if ("id2".equals(id)) {
+                Assert.assertEquals(matchName,
+                                    "match_message");
+            }
+            else if ("id3".equals(id)) {
+                Assert.assertEquals(matchName,
+                                    "match_exception");
+            }
+            else if ("id4".equals(id)) {
+                Assert.assertTrue("Expected 'match_exception' or 'match_message'",
+                                  "match_exception".equals(matchName)||"match_message".equals(matchName));
+            }
+        });
+    }
+
+    /**
+     * No filtering (all records are sent out).
+     * Records that match more than one query are duplicated.
+     */
+    @Test
+    public void validateNoFiltering() {
+        final TestRunner testRunner = TestRunners.newTestRunner(new MatchQuery());
+        testRunner.setProperty(MatchQuery.ON_MISS_POLICY, MatchQuery.OnMissPolicy.forward.toString());
+        testRunner.setProperty("match_exception", "exception:match");
+        testRunner.setProperty("match_message", "message:match");
+        testRunner.assertValid();
+        testRunner.clearQueues();
+        testRunner.enqueue(RECORDS);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        List<MockRecord> records = testRunner.getOutputRecords();
+        testRunner.assertOutputRecordsCount(5); // All records + id4 duplicated.
+
+        records.forEach(record -> {
+            final String id = record.getId();
+
+            final Field field = record.getField(MatchQuery.ALERT_MATCH_NAME);
+
+            Object matchName = null;
+            if (field!=null) {
+                final Object _matchName = field.getRawValue();
+                // One match name per record.
+                Assert.assertEquals(_matchName.getClass(),
+                                    String.class);
+                matchName = (String) _matchName;
+            }
+
+            if ("id1".equals(id)) {
+                // No match
+                Assert.assertNull(field);
+            }
+            else if ("id2".equals(id)) {
+                Assert.assertEquals(matchName,
+                                    "match_message");
+            }
+            else if ("id3".equals(id)) {
+                Assert.assertEquals(matchName,
+                                    "match_exception");
+            }
+            else if ("id4".equals(id)) {
+                Assert.assertTrue("Expected 'match_exception' or 'match_message'",
+                                  "match_exception".equals(matchName)||"match_message".equals(matchName));
+            }
+        });
+    }
+
+    /**
+     * Only matching records are not filtered out.
+     * Records that match more than one query are NOT duplicated but the matching query information are
+     * concatenated in record fields.
+     */
+    @Test
+    public void validateFilteredConcat() {
+        final TestRunner testRunner = TestRunners.newTestRunner(new MatchQuery());
+        testRunner.setProperty(MatchQuery.ON_MATCH_POLICY, MatchQuery.OnMatchPolicy.all.toString());
+        testRunner.setProperty("match_exception", "exception:match");
+        testRunner.setProperty("match_message", "message:match");
+        testRunner.assertValid();
+        testRunner.clearQueues();
+        testRunner.enqueue(RECORDS);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        List<MockRecord> records = testRunner.getOutputRecords();
+        testRunner.assertOutputRecordsCount(3);
+
+        records.forEach(record -> {
+            final String id = record.getId();
+
+            final Field field = record.getField(MatchQuery.ALERT_MATCH_NAME);
+
+            String[] matchName = null;
+            if (field!=null) {
+                final Object _matchName = field.getRawValue();
+                // One match name per record.
+                Assert.assertEquals(_matchName.getClass(),
+                                    String[].class);
+                matchName = (String[]) _matchName;
+            }
+
+            if ("id1".equals(id)) {
+                // No match
+                Assert.fail("Unexpected match for id1");
+            }
+            else if ("id2".equals(id)) {
+                Assert.assertEquals(matchName[0],
+                                    "match_message");
+            }
+            else if ("id3".equals(id)) {
+                Assert.assertEquals(matchName[0],
+                                    "match_exception");
+            }
+            else if ("id4".equals(id)) {
+                Assert.assertTrue("Expected 'match_exception' or 'match_message' but has "+matchName[0],
+                                  "match_exception".equals(matchName[0])||"match_message".equals(matchName[0]));
+
+                Assert.assertTrue("Expected 'match_exception' or 'match_message' but has "+matchName[1],
+                                  "match_exception".equals(matchName[1])||"match_message".equals(matchName[1]));
+            }
+        });
+    }
+
+    /**
+     * No filtering (all records are sent out).
+     * Records that match more than one query are NOT duplicated but the matching query information are
+     * concatenated in record fields.
+     */
+    @Test
+    public void validateNoFilteringConcat() {
+        final TestRunner testRunner = TestRunners.newTestRunner(new MatchQuery());
+        testRunner.setProperty(MatchQuery.ON_MATCH_POLICY, MatchQuery.OnMatchPolicy.all.toString());
+        testRunner.setProperty(MatchQuery.ON_MISS_POLICY, MatchQuery.OnMissPolicy.forward.toString());
+        testRunner.setProperty("match_exception", "exception:match");
+        testRunner.setProperty("match_message", "message:match");
+        testRunner.assertValid();
+        testRunner.clearQueues();
+        testRunner.enqueue(RECORDS);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        List<MockRecord> records = testRunner.getOutputRecords();
+        testRunner.assertOutputRecordsCount(4);
+
+        records.forEach(record -> {
+            final String id = record.getId();
+
+            final Field field = record.getField(MatchQuery.ALERT_MATCH_NAME);
+
+            String[] matchName = null;
+            if (field!=null) {
+                final Object _matchName = field.getRawValue();
+                // One match name per record.
+                Assert.assertEquals(_matchName.getClass(),
+                                    String[].class);
+                matchName = (String[]) _matchName;
+            }
+
+            if ("id1".equals(id)) {
+                // No match
+                Assert.assertNull(field);
+            }
+            else if ("id2".equals(id)) {
+                Assert.assertEquals(matchName[0],
+                                    "match_message");
+            }
+            else if ("id3".equals(id)) {
+                Assert.assertEquals(matchName[0],
+                                    "match_exception");
+            }
+            else if ("id4".equals(id)) {
+                Assert.assertTrue("Expected 'match_exception' or 'match_message' but has "+matchName[0],
+                                  "match_exception".equals(matchName[0])||"match_message".equals(matchName[0]));
+
+                Assert.assertTrue("Expected 'match_exception' or 'match_message' but has "+matchName[1],
+                                  "match_exception".equals(matchName[1])||"match_message".equals(matchName[1]));
+            }
+        });
+    }
+
+    /**
+     * Queries do not match any record but as the onmiss.policy:forward, all non-matching records are forwarded anyway.
+     */
+    @Test
+    public void validateNoMatchForward() {
+        final TestRunner testRunner = TestRunners.newTestRunner(new MatchQuery());
+        testRunner.setProperty(MatchQuery.ON_MISS_POLICY, "forward");
+        testRunner.assertValid();
+        testRunner.clearQueues();
+        testRunner.enqueue(RECORDS);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(4);
+    }
+
+    /**
+     * Queries match fields that contain 'good' (id1) or 'wrong' (id2) and all non-matching records are forwarded
+     * anyway.
+     */
+    @Test
+    public void validateOneMatchForward() {
+        final TestRunner testRunner = TestRunners.newTestRunner(new MatchQuery());
+        testRunner.setProperty(MatchQuery.ON_MISS_POLICY, "forward");
+        testRunner.setProperty("too_many_attempts_exception", "exception:TooManyAttemptsException");
+        testRunner.setProperty("some_message", "message:(good|wrong)");
+        testRunner.assertValid();
+
+        Record[] records = {
+                new StandardRecord(EXCEPTION_RECORD)
+                        .setId("id1")
+                        .setStringField("exception", "NullPointerException")
+                        .setStringField("message", "something good"),
+                new StandardRecord(EXCEPTION_RECORD)
+                        .setId("id2")
+                        .setStringField("exception", "IllegalStateException")
+                        .setStringField("message", "something wrong"),
+                new StandardRecord(EXCEPTION_RECORD)
+                        .setId("id3")
+                        .setStringField("exception", "BadBoyException")
+                        .setStringField("message", "oh bad boy!")
+        };
+        testRunner.clearQueues();
+        testRunner.enqueue(records);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(3);
+    }
 }


### PR DESCRIPTION
This PR brings two new properties on the MatchQuery processor:

policy.onmiss: 'discard' (default value) drop events that did not match any query;
'forward' include also events that did not match any query.
policy.onmatch: 'first' (default value) match events are tagged with the name and value of the first query that matched;
'all' match events are tagged with all names and values of the queries that matched.