### PR TITLE
Fix for issue #311

### DIFF
--- a/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchQuery.java
+++ b/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchQuery.java
@@ -221,25 +221,26 @@ public class MatchQuery extends AbstractProcessor {
         for (final Record record : records) {
             final InputDocument.Builder docbuilder = InputDocument.builder(record.getId());
             for (final String fieldName : record.getAllFieldNames()) {
-
-                switch (record.getField(fieldName).getType()) {
-                    case STRING:
-                        docbuilder.addField(fieldName, record.getField(fieldName).asString(), stopAnalyzer);
-                        break;
-                    case INT:
-                        docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asInteger(), Field.Store.YES));
-                        break;
-                    case LONG:
-                        docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asLong(), Field.Store.YES));
-                        break;
-                    case FLOAT:
-                        docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asFloat(), Field.Store.YES));
-                        break;
-                    case DOUBLE:
-                        docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asDouble(), Field.Store.YES));
-                        break;
-                    default:
-                        docbuilder.addField(fieldName, record.getField(fieldName).asString(), keywordAnalyzer);
+                if (record.getField(fieldName).getRawValue() != null) {
+                    switch (record.getField(fieldName).getType()) {
+                        case STRING:
+                            docbuilder.addField(fieldName, record.getField(fieldName).asString(), stopAnalyzer);
+                            break;
+                        case INT:
+                            docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asInteger(), Field.Store.YES));
+                            break;
+                        case LONG:
+                            docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asLong(), Field.Store.YES));
+                            break;
+                        case FLOAT:
+                            docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asFloat(), Field.Store.YES));
+                            break;
+                        case DOUBLE:
+                            docbuilder.addField(new LegacyDoubleField(fieldName, record.getField(fieldName).asDouble(), Field.Store.YES));
+                            break;
+                        default:
+                            docbuilder.addField(fieldName, record.getField(fieldName).asString(), keywordAnalyzer);
+                    }
                 }
             }
 


### PR DESCRIPTION
Logisland Query Matcher processor should handle properly records with fields having no (null) values.
But when handling records containing fields with null values, Logisland hits the following NPE :

2017-07-25 15:00:32 ERROR Executor:95 - Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.IllegalArgumentException: value must not be null
at shade.logisland.querymatcher.org.apache.lucene.document.Field.(Field.java:246)
at shade.logisland.querymatcher.uk.co.flax.luwak.InputDocument$Builder.addField(InputDocument.java:130)
at com.hurence.logisland.processor.MatchQuery.process(MatchQuery.java:242)