### PR TITLE
Support for rfe #314 - MatchQuery processor is able to keep the recor…

### DIFF
--- a/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchHandlers.java
+++ b/logisland-plugins/logisland-querymatcher-plugin/src/main/java/com/hurence/logisland/processor/MatchHandlers.java
@@ -49,7 +49,8 @@ class MatchHandlers {
          */
         void handleMatch(Record record,
                          ProcessContext context,
-                         MatchingRule matchingRule);
+                         MatchingRule matchingRule,
+                         MatchQuery.RecordTypeUpdatePolicy recordTypeUpdatePolicy);
 
         /**
          * Returns the processed records.
@@ -71,11 +72,16 @@ class MatchHandlers {
         @Override
         public void handleMatch(final Record record,
                                 final ProcessContext context,
-                                final MatchingRule matchingRule) {
+                                final MatchingRule matchingRule,
+                                MatchQuery.RecordTypeUpdatePolicy recordTypeUpdatePolicy) {
             this.outRecords.add(
-                    new StandardRecord(record).setType(context.getPropertyValue(MatchQuery.OUTPUT_RECORD_TYPE).asString())
-                                              .setStringField(ALERT_MATCH_NAME, matchingRule.getName())
-                                              .setStringField(ALERT_MATCH_QUERY, matchingRule.getQuery()));
+                    new StandardRecord(record)
+                            .setType(
+                                (recordTypeUpdatePolicy == MatchQuery.RecordTypeUpdatePolicy.overwrite) ?
+                                        context.getPropertyValue(MatchQuery.OUTPUT_RECORD_TYPE).asString() : record.getType()
+                            )
+                            .setStringField(ALERT_MATCH_NAME, matchingRule.getName())
+                            .setStringField(ALERT_MATCH_QUERY, matchingRule.getQuery()));
         }
 
         @Override
@@ -97,7 +103,8 @@ class MatchHandlers {
         @Override
         public void handleMatch(final Record record,
                                 final ProcessContext context,
-                                final MatchingRule matchingRule) {
+                                final MatchingRule matchingRule,
+                                MatchQuery.RecordTypeUpdatePolicy recordTypeUpdatePolicy) {
             com.hurence.logisland.record.Field nameField = null;
             com.hurence.logisland.record.Field queryField = null;
 
@@ -105,7 +112,11 @@ class MatchHandlers {
 
             if ( outRecord == null ) {
                 // First match. Clone record and set query information.
-                outRecord = new StandardRecord(record).setType(context.getPropertyValue(MatchQuery.OUTPUT_RECORD_TYPE).asString());
+                outRecord = new StandardRecord(record).setType(
+                        (recordTypeUpdatePolicy == MatchQuery.RecordTypeUpdatePolicy.overwrite) ?
+                                context.getPropertyValue(MatchQuery.OUTPUT_RECORD_TYPE).asString() :
+                                record.getType()
+                );
                 this.outRecords.put(record.getId(), outRecord);
 
                 // Keep all matched query information.
@@ -167,9 +178,10 @@ class MatchHandlers {
         @Override
         public void handleMatch(final Record record,
                                 final ProcessContext context,
-                                final MatchingRule matchingRule) {
+                                final MatchingRule matchingRule,
+                                MatchQuery.RecordTypeUpdatePolicy recordTypeUpdatePolicy) {
             // Forward processing of tagging to either only first or concat matchHandler.
-            this.matchHandler.handleMatch(record, context, matchingRule);
+            this.matchHandler.handleMatch(record, context, matchingRule, recordTypeUpdatePolicy);
             // Remove the processed record from the records to append in case of non-match.
             inputRecords.remove(record.getId());
         }


### PR DESCRIPTION
Actual MatchQuery processor does overwrite the record type when the record matches the query.
While it makes sense in some use-cases, it is also important to keep the legacy record type and just tag appropriately the matching record.

Therefore the proposal is to introduce a new optional property such as a Record type Update Policy.
By default the processor will overwrite the record type and when set appropriately it will let the original type unchanged.