### PR TITLE
Implementation proposal for RFE #316 - Need for a SplitField processor

### DIFF
--- a/logisland-plugins/logisland-common-processors-plugin/src/main/java/com/hurence/logisland/processor/SplitField.java
+++ b/logisland-plugins/logisland-common-processors-plugin/src/main/java/com/hurence/logisland/processor/SplitField.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (C) 2016 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hurence.logisland.processor;
+
+import com.hurence.logisland.annotation.behavior.DynamicProperty;
+import com.hurence.logisland.annotation.documentation.CapabilityDescription;
+import com.hurence.logisland.annotation.documentation.SeeAlso;
+import com.hurence.logisland.annotation.documentation.Tags;
+import com.hurence.logisland.component.AllowableValue;
+import com.hurence.logisland.component.PropertyDescriptor;
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.validator.StandardValidators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+
+@Tags({"parser", "split", "log", "record"})
+@CapabilityDescription("This processor is used to create a new set of fields from one field (using split).")
+@SeeAlso(value = {SplitField.class}, classNames = {"com.hurence.logisland.processor.SplitField"})
+@DynamicProperty(name = "alternative split field",
+        supportsExpressionLanguage = true,
+        value = "another split that could match",
+        description = "This processor is used to create a new set of fields from one field (using split).")
+public class SplitField extends AbstractProcessor {
+
+    private Map<String, regexRule> fieldsNameMapping;
+    private String splitCounterSuffix;
+    private boolean isEnabledSplitCounter;
+    private int nbSplitLimit;
+
+    static final long serialVersionUID = 1413578915552852739L;
+
+    private static Logger logger = LoggerFactory.getLogger(SplitField.class);
+
+    public static final PropertyDescriptor NB_SPLIT_LIMIT = new PropertyDescriptor.Builder()
+            .name("split.limit")
+            .description("Specify the maximum number of split to allow")
+            .required(false)
+            .defaultValue("10")
+            .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+            .build();
+
+    public static final AllowableValue OVERWRITE_EXISTING =
+            new AllowableValue("overwrite_existing", "overwrite existing field", "if field already exist");
+
+    public static final AllowableValue KEEP_OLD_FIELD =
+            new AllowableValue("keep_only_old_field", "keep only old field", "keep only old field");
+
+    public static final PropertyDescriptor ENABLE_SPLIT_COUNTER = new PropertyDescriptor.Builder()
+            .name("split.counter.enable")
+            .description("Enable the counter of items returned by the split")
+            .required(false)
+            .defaultValue("false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor SPLIT_COUNTER_SUFFIX = new PropertyDescriptor.Builder()
+            .name("split.counter.suffix")
+            .description("Enable the counter of items returned by the split")
+            .required(false)
+            .defaultValue("Counter")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor CONFLICT_RESOLUTION_POLICY = new PropertyDescriptor.Builder()
+            .name("conflict.resolution.policy")
+            .description("What to do when a field with the same name already exists ?")
+            .required(false)
+            .defaultValue(KEEP_OLD_FIELD.getValue())
+            .allowableValues(OVERWRITE_EXISTING, KEEP_OLD_FIELD)
+            .build();
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(CONFLICT_RESOLUTION_POLICY);
+        descriptors.add(NB_SPLIT_LIMIT);
+        descriptors.add(ENABLE_SPLIT_COUNTER);
+        descriptors.add(SPLIT_COUNTER_SUFFIX);
+        return Collections.unmodifiableList(descriptors);
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .expressionLanguageSupported(false)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .required(false)
+                .dynamic(true)
+                .build();
+    }
+
+    @Override
+    public void init(final ProcessContext context) {
+        this.fieldsNameMapping = getFieldsNameMapping(context);
+        this.nbSplitLimit = context.getPropertyValue(NB_SPLIT_LIMIT).asInteger();
+        this.isEnabledSplitCounter = context.getPropertyValue(ENABLE_SPLIT_COUNTER).asBoolean();
+        this.splitCounterSuffix = context.getPropertyValue(SPLIT_COUNTER_SUFFIX).asString();
+    }
+
+    @Override
+    public Collection<Record> process(ProcessContext context, Collection<Record> records) {
+
+        if ((fieldsNameMapping == null) || fieldsNameMapping.isEmpty()){
+            return records;
+        }
+
+        /**
+         * try to match the regexp to create an event
+         */
+        records.forEach(record -> {
+            try {
+                for (String sourceAttr : fieldsNameMapping.keySet()){
+                    if (record.hasField(sourceAttr) &&
+                            (record.getField(sourceAttr).asString() != null) &&
+                            (! record.getField(sourceAttr).asString().isEmpty())){
+                        regexRule mappingRule = fieldsNameMapping.get(sourceAttr);
+                        if (mappingRule.getSplitRegexp() != null){
+                            // Apply the regex to the value
+                            String fieldValue = record.getField(sourceAttr).asString();
+                            try {
+                                String splitR = mappingRule.getSplitRegexp();
+                                String[] values = fieldValue.split(splitR, nbSplitLimit);
+                                if (values != null) {
+                                    // Add the array of values to the new field to create.
+                                    extractValueFields(mappingRule.getFieldToProduce(), record, values, context);
+                                }
+                            }
+                            catch(Exception e){
+                                logger.warn("issue while matching on record {}, exception {}", record, e.getMessage());
+                            }
+
+                        }
+                        else {
+                            // There is no defined regexp.
+                            // Simply ignore the mapping rule
+                            continue;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                // nothing to do here
+                logger.warn("issue while matching getting K/V on record {}, exception {}", record, e.getMessage());
+            }
+        });
+
+        return records;
+    }
+
+
+    private void extractValueFields(String valueField, Record outputRecord, String[] values, ProcessContext context) {
+        String conflictPolicy = context.getPropertyValue(CONFLICT_RESOLUTION_POLICY).asString();
+        String fieldName = valueField;
+
+        if (outputRecord.hasField(fieldName) &&
+                (outputRecord.getField(fieldName).asString() != null) &&
+                (! outputRecord.getField(fieldName).asString().isEmpty())) {
+            if (conflictPolicy.equals(OVERWRITE_EXISTING.getValue())) {
+                //outputRecord.setStringField(fieldName, content.replaceAll("\"", ""));
+                outputRecord.setField(fieldName, FieldType.ARRAY, values);
+                if (this.isEnabledSplitCounter){
+                    outputRecord.setField(fieldName+this.splitCounterSuffix, FieldType.INT, values.length);
+                }
+            }
+        }
+        else {
+            outputRecord.setField(fieldName, FieldType.ARRAY, values);
+            //outputRecord.setStringField(fieldName, content.replaceAll("\"", ""));
+            if (this.isEnabledSplitCounter){
+                outputRecord.setField(fieldName+this.splitCounterSuffix, FieldType.INT, values.length);
+            }
+        }
+    }
+
+    private class regexRule {
+        private String fieldToProduce;
+        private String splitRegexp = null;
+
+        public String getSplitRegexp() {return splitRegexp;}
+
+        public String getFieldToProduce() {
+            return fieldToProduce;
+        }
+
+        public regexRule(String field, String r){
+            fieldToProduce = field;
+            if (r != null) {
+                splitRegexp = r;
+                // Check the given expression to use in split is correct.
+                // Raise a PatternSyntaxException if incorrect.
+                Pattern.compile(r);
+            }
+        }
+    }
+
+    /*
+     * Build a map of mapping rules of the form:
+     *
+     */
+    private Map<String, regexRule> getFieldsNameMapping(ProcessContext context) {
+        /**
+         * list alternative regex
+         */
+        Map<String, regexRule> fieldsNameMappings = new HashMap<>();
+        // loop over dynamic properties to add alternative regex
+        for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
+            if (!entry.getKey().isDynamic()) {
+                continue;
+            }
+
+            final String fieldName = entry.getKey().getName();
+            final String[] splitedElements = entry.getValue().split(":", 2);
+            if (splitedElements.length == 2) {
+                String fieldToProduce = splitedElements[0];
+                String regexp = splitedElements[1];
+                fieldsNameMappings.put(fieldName, new regexRule(fieldToProduce, regexp));
+            }
+            else {
+                // Ignore the mapping rule
+                logger.warn("The mapping rule for {} has the invalid value: {}", entry.getKey().getName(), entry.getValue());
+            }
+        }
+        return fieldsNameMappings;
+    }
+
+}

--- a/logisland-plugins/logisland-common-processors-plugin/src/test/java/com/hurence/logisland/processor/SplitFieldTest.java
+++ b/logisland-plugins/logisland-common-processors-plugin/src/test/java/com/hurence/logisland/processor/SplitFieldTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2016 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hurence.logisland.processor;
+
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.record.StandardRecord;
+import com.hurence.logisland.util.runner.MockRecord;
+import com.hurence.logisland.util.runner.TestRunner;
+import com.hurence.logisland.util.runner.TestRunners;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SplitFieldTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(SplitFieldTest.class);
+
+    private Record getRecord() {
+        Record record1 = new StandardRecord();
+        record1.setField("location", FieldType.STRING, "https://www.mycompany.com/fr/search");
+        record1.setField("description", FieldType.STRING, "text1-text2");
+        record1.setField("description1", FieldType.STRING, "outil+meuleuse+rapide");
+        record1.setField("description2", FieldType.STRING, "outil+meu.leu.se+rapide++");
+        record1.setField("long1", FieldType.LONG, 1);
+        record1.setField("long2", FieldType.LONG, 2);
+        return record1;
+    }
+
+    @Test
+    public void testNoRegexp() {
+        Record record1 = getRecord();
+
+        TestRunner testRunner = TestRunners.newTestRunner(new SplitField());
+        testRunner.setProperty("location", "companyName");
+        testRunner.assertValid();
+        testRunner.enqueue(record1);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(1);
+
+        MockRecord out = testRunner.getOutputRecords().get(0);
+        out.assertRecordSizeEquals(6);
+    }
+
+    @Test
+    public void testEmptyRegexp() {
+        Record record1 = getRecord();
+
+        TestRunner testRunner = TestRunners.newTestRunner(new SplitField());
+        testRunner.setProperty("location", "companyName:");
+        testRunner.assertValid();
+        testRunner.enqueue(record1);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(1);
+
+        MockRecord out = testRunner.getOutputRecords().get(0);
+        out.assertRecordSizeEquals(7);
+    }
+
+    @Test
+    public void testRegexpSimple() {
+
+        Record record1 = getRecord();
+
+        TestRunner testRunner = TestRunners.newTestRunner(new SplitField());
+        //testRunner.setProperty("description", "textArray:https\\:\\/\\/www\\.(\\w+\\.\\w+)\\/?.*");
+        testRunner.setProperty("description", "textArray:-");
+        testRunner.assertValid();
+        testRunner.enqueue(record1);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(1);
+
+        MockRecord out = testRunner.getOutputRecords().get(0);
+        out.assertRecordSizeEquals(7);
+        //out.assertFieldEquals("companyName", "mycompany.com");
+    }
+
+    @Test
+    public void testRegexpAdvanced01() {
+
+        Record record1 = getRecord();
+
+        TestRunner testRunner = TestRunners.newTestRunner(new SplitField());
+        //testRunner.setProperty("description", "textArray:https\\:\\/\\/www\\.(\\w+\\.\\w+)\\/?.*");
+        testRunner.setProperty("description1", "descArray:\\s*\\+\\s*");
+        testRunner.setProperty("split.counter.enable","true");
+        testRunner.setProperty("split.counter.suffix", "Counter");
+        testRunner.assertValid();
+        testRunner.enqueue(record1);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(1);
+
+        MockRecord out = testRunner.getOutputRecords().get(0);
+        out.assertRecordSizeEquals(8);
+        out.assertFieldEquals("descArrayCounter", "3");
+    }
+
+
+    @Test
+    public void testRegexpAdvanced02() {
+
+        Record record1 = getRecord();
+
+        TestRunner testRunner = TestRunners.newTestRunner(new SplitField());
+        //testRunner.setProperty("description", "textArray:https\\:\\/\\/www\\.(\\w+\\.\\w+)\\/?.*");
+        testRunner.setProperty("description2", "descArray:\\s*\\+\\s*");
+        testRunner.setProperty("split.counter.enable","true");
+        testRunner.setProperty("split.counter.suffix", "Counter");
+        testRunner.assertValid();
+        testRunner.enqueue(record1);
+        testRunner.run();
+        testRunner.assertAllInputRecordsProcessed();
+        testRunner.assertOutputRecordsCount(1);
+
+        MockRecord out = testRunner.getOutputRecords().get(0);
+        out.assertRecordSizeEquals(8);
+        out.assertFieldEquals("descArrayCounter", "5");
+    }
+}


### PR DESCRIPTION
There is a need to be able to split a field (using the java split api) and build an array of values out of it.
The idea would be to have smth pretty similar to what is already available in the ApplyRegexp processor but for split.
It would make sense to be able to define as many split rule as what is needed. (i-e dynamic configuration)

Proposal of configuration:
- processor: Split search keywords and count number of keywords
component: com.hurence.logisland.processor.SplitField
type: processor
documentation: a processor that splits a string and return an array of values
configuration:
productSearchKeywords: productSearchKeywordsArray:\s*+\s*

