### PR TITLE
Take into account spark properties file in logisland.sh

### DIFF
--- a/logisland-framework/logisland-resources/src/main/resources/bin/logisland.sh
+++ b/logisland-framework/logisland-resources/src/main/resources/bin/logisland.sh
@@ -253,7 +253,14 @@ case $MODE in
     ;;
 esac
 
-java_cmd="${SPARK_HOME}/bin/spark-submit ${VERBOSE_OPTIONS} ${YARN_CLUSTER_OPTIONS} ${YARN_APP_NAME_OPTIONS} \
+PROPERTIES_FILE=""
+PROPERTIES_FILE_PATH=`awk '{ if( $1 == "spark.properties.file.path:" ){ print $2 } }' ${CONF_FILE}`
+if [ ! -z "${PROPERTIES_FILE_PATH}" ]
+then
+     PROPERTIES_FILE=" --properties-file ${PROPERTIES_FILE_PATH} "
+fi
+
+java_cmd="${SPARK_HOME}/bin/spark-submit ${VERBOSE_OPTIONS} ${YARN_CLUSTER_OPTIONS} ${PROPERTIES_FILE} ${YARN_APP_NAME_OPTIONS} \
     --class ${app_mainclass} \
     --jars ${app_classpath} \
     ${lib_dir}/logisland-spark*-engine*.jar \


### PR DESCRIPTION
The properties file path is set in logisland conf file (yml) via the "spark.properties.file.path" parameter :

> spark.properties.file.path: /path/to/spark/properties/file

In this properties file, extra configuration can be set. For example, export of spark JMX metrics :

> spark.driver.extraJavaOptions   -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8094 -Dcom.sun.management.jmxremote.rmi.port=8095 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=51.15.164.141 -javaagent:/opt/jmx/jmx_prometheus_javaagent-0.9.jar=7092:/opt/jmx/jmx_prometheus.yml