### PR TITLE
Update parseGitlabLog processor to handle new way of logging

### DIFF
--- a/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/runner/MockRecord.java
+++ b/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/runner/MockRecord.java
@@ -89,6 +89,14 @@ public class MockRecord extends StandardRecord {
        // assertedFields.add(fieldName);
     }
 
+    public void assertNullField(final String fieldName) {
+        Assert.assertNull(getField(fieldName).getRawValue());
+    }
+
+    public void assertNotNullField(final String fieldName) {
+        Assert.assertNotNull(getField(fieldName).getRawValue());
+    }
+
     public void assertFieldNotEquals(final String fieldName, final String expectedValue) {
         Assert.assertNotSame(expectedValue, getField(fieldName).asString());
 		//assertedFields.add(fieldName);


### PR DESCRIPTION
Params logging has changed in the latest gitlab updates. The processor is also updated to reflect changes and also to set params json field and sub fields as first level fields in order to ease the queries when mining through a search engine (ES or Solr).