### PR TITLE
Added keep fields feature to RemoveFields processor

### DIFF
--- a/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/RemoveFields.java
+++ b/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/RemoveFields.java
@@ -19,8 +19,11 @@ import com.google.common.collect.Lists;
 import com.hurence.logisland.annotation.documentation.CapabilityDescription;
 import com.hurence.logisland.annotation.documentation.Tags;
 import com.hurence.logisland.component.PropertyDescriptor;
+import com.hurence.logisland.component.PropertyValue;
 import com.hurence.logisland.record.Record;
 import com.hurence.logisland.validator.StandardValidators;
+import com.hurence.logisland.validator.ValidationContext;
+import com.hurence.logisland.validator.ValidationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,50 +32,159 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-@Tags({"record", "fields", "remove", "delete"})
-@CapabilityDescription("Removes a list of fields defined by a comma separated list of field names")
+@Tags({"record", "fields", "remove", "delete", "keep"})
+@CapabilityDescription("Removes a list of fields defined by a comma separated list of field names or keeps only fields " +
+        "defined by a comma separated list of field names.")
 public class RemoveFields extends AbstractProcessor {
 
     private static final long serialVersionUID = -270933070438408174L;
 
+    public static final String KEY_FIELDS_TO_REMOVE = "fields.to.remove";
+    public static final String KEY_FIELDS_TO_KEEP = "fields.to.keep";
+
     private static final Logger logger = LoggerFactory.getLogger(RemoveFields.class);
 
     public static final PropertyDescriptor FIELDS_TO_REMOVE = new PropertyDescriptor.Builder()
-            .name("fields.to.remove")
-            .description("the comma separated list of field names (e.g. 'policyid,date_raw'")
-            .required(true)
+            .name(KEY_FIELDS_TO_REMOVE)
+            .description("A comma separated list of field names to remove (e.g. 'policyid,date_raw'). Usage of this " +
+                    "property is mutually exclusive with the " + KEY_FIELDS_TO_KEEP + " property")
+            .required(false)
             .addValidator(StandardValidators.COMMA_SEPARATED_LIST_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor FIELDS_TO_KEEP = new PropertyDescriptor.Builder()
+            .name(KEY_FIELDS_TO_KEEP)
+            .description("A comma separated list of field names to keep (e.g. 'policyid,date_raw'. All other fields " +
+                    "will be removed. Usage of this property is mutually exclusive with the " + FIELDS_TO_REMOVE +
+                    " property")
+            .required(false)
+            .addValidator(StandardValidators.COMMA_SEPARATED_LIST_VALIDATOR)
+            .build();
+
+    // Remove or keep mode
+    private boolean remove;
+    private List<String> fieldsToRemove;
+    List<String> fieldsToKeep;
+
+    @Override
+    public void init(ProcessContext context) {
+
+        PropertyValue propertyValue = context.getPropertyValue(FIELDS_TO_REMOVE);
+
+        if (propertyValue.asString() == null)
+        {
+            remove = false;
+            propertyValue = context.getPropertyValue(FIELDS_TO_KEEP);
+            fieldsToKeep = Lists.newArrayList(propertyValue.asString().split(","));
+        } else
+        {
+            remove = true;
+            fieldsToRemove = Lists.newArrayList(propertyValue.asString().split(","));
+        }
+    }
 
     @Override
     public Collection<Record> process(ProcessContext context, Collection<Record> records) {
 
         try {
-            List<String> fieldsToRemove = Lists.newArrayList(
-                    context.getPropertyValue(FIELDS_TO_REMOVE).asString().split(","));
-
             for (Record record : records) {
                 new ArrayList<>(record.getAllFields()).forEach(field -> {
                     String fieldName = field.getName();
-                    if (fieldsToRemove.contains(fieldName)) {
-                        record.removeField(fieldName);
+                    if (remove) {
+                        // Remove mode
+                        if (fieldsToRemove.contains(fieldName)) {
+                            record.removeField(fieldName);
+                        }
+                    }
+                    else
+                    {
+                        // Keep mode
+                        if (!fieldsToKeep.contains(fieldName)) {
+                            record.removeField(fieldName);
+                        }
                     }
                 });
             }
         } catch (Exception ex) {
-            logger.warn("issue while trying to remove field list {} :  {}",
-                    context.getPropertyValue(FIELDS_TO_REMOVE).asString(),
-                    ex.toString());
+            if (remove) {
+                logger.warn("issue while trying to remove field list {} :  {}",
+                        context.getPropertyValue(FIELDS_TO_REMOVE).asString(),
+                        ex.toString());
+            }
+            else
+            {
+                logger.warn("issue while trying to handle keep field list {} :  {}",
+                        context.getPropertyValue(FIELDS_TO_KEEP).asString(),
+                        ex.toString());
+            }
         }
 
         return records;
     }
 
-
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return Collections.unmodifiableList(
-                Lists.newArrayList(FIELDS_TO_REMOVE));
+                Lists.newArrayList(FIELDS_TO_REMOVE, FIELDS_TO_KEEP));
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext context) {
+
+        final List<ValidationResult> validationResults = new ArrayList<>(super.customValidate(context));
+
+        /**
+         * Only one of both properties may be set.
+         */
+
+        // Be sure not both are defined
+        if (context.getPropertyValue(FIELDS_TO_REMOVE).isSet() && context.getPropertyValue(FIELDS_TO_KEEP).isSet())
+        {
+            validationResults.add(
+                    new ValidationResult.Builder()
+                            .explanation(FIELDS_TO_REMOVE.getName() + " and " + FIELDS_TO_KEEP.getName() +
+                                    " properties are mutually exclusive.")
+                            .valid(false)
+                            .build());
+        }
+
+        // Be sure at least one is defined
+        if (!context.getPropertyValue(FIELDS_TO_REMOVE).isSet() && !context.getPropertyValue(FIELDS_TO_KEEP).isSet())
+        {
+            validationResults.add(
+                    new ValidationResult.Builder()
+                            .explanation("One of both properties " + FIELDS_TO_REMOVE.getName() + " or " +
+                                    FIELDS_TO_KEEP.getName() + " should be defined.")
+                            .valid(false)
+                            .build());
+        }
+
+        /**
+         * No empty values
+         */
+
+        if (context.getPropertyValue(FIELDS_TO_REMOVE).isSet())
+        {
+            if (context.getPropertyValue(FIELDS_TO_REMOVE).asString().trim().length() == 0) {
+                validationResults.add(
+                        new ValidationResult.Builder()
+                                .explanation(FIELDS_TO_REMOVE.getName() + " cannot be empty if set.")
+                                .valid(false)
+                                .build());
+            }
+        }
+
+        if (context.getPropertyValue(FIELDS_TO_KEEP).isSet())
+        {
+            if (context.getPropertyValue(FIELDS_TO_KEEP).asString().trim().length() == 0) {
+                validationResults.add(
+                        new ValidationResult.Builder()
+                                .explanation(FIELDS_TO_KEEP.getName() + " cannot be empty if set.")
+                                .valid(false)
+                                .build());
+            }
+        }
+
+        return validationResults;
     }
 }

--- a/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/RemoveFields.java
+++ b/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/RemoveFields.java
@@ -20,6 +20,7 @@ import com.hurence.logisland.annotation.documentation.CapabilityDescription;
 import com.hurence.logisland.annotation.documentation.Tags;
 import com.hurence.logisland.component.PropertyDescriptor;
 import com.hurence.logisland.component.PropertyValue;
+import com.hurence.logisland.record.FieldDictionary;
 import com.hurence.logisland.record.Record;
 import com.hurence.logisland.validator.StandardValidators;
 import com.hurence.logisland.validator.ValidationContext;
@@ -47,7 +48,10 @@ public class RemoveFields extends AbstractProcessor {
     public static final PropertyDescriptor FIELDS_TO_REMOVE = new PropertyDescriptor.Builder()
             .name(KEY_FIELDS_TO_REMOVE)
             .description("A comma separated list of field names to remove (e.g. 'policyid,date_raw'). Usage of this " +
-                    "property is mutually exclusive with the " + KEY_FIELDS_TO_KEEP + " property")
+                    "property is mutually exclusive with the " + KEY_FIELDS_TO_KEEP + " property. In any case the " +
+                    "technical logisland fields " + FieldDictionary.RECORD_ID + ", " + FieldDictionary.RECORD_TIME +
+                    " and " + FieldDictionary.RECORD_TYPE + " are not removed even if specified in the list to " +
+                    "remove.")
             .required(false)
             .addValidator(StandardValidators.COMMA_SEPARATED_LIST_VALIDATOR)
             .build();
@@ -56,7 +60,9 @@ public class RemoveFields extends AbstractProcessor {
             .name(KEY_FIELDS_TO_KEEP)
             .description("A comma separated list of field names to keep (e.g. 'policyid,date_raw'. All other fields " +
                     "will be removed. Usage of this property is mutually exclusive with the " + FIELDS_TO_REMOVE +
-                    " property")
+                    " property. In any case the technical logisland fields " + FieldDictionary.RECORD_ID +
+                    ", " + FieldDictionary.RECORD_TIME + " and " + FieldDictionary.RECORD_TYPE + " are not removed " +
+                    "even if not specified in the list to keep.")
             .required(false)
             .addValidator(StandardValidators.COMMA_SEPARATED_LIST_VALIDATOR)
             .build();
@@ -98,9 +104,13 @@ public class RemoveFields extends AbstractProcessor {
                     }
                     else
                     {
-                        // Keep mode
-                        if (!fieldsToKeep.contains(fieldName)) {
-                            record.removeField(fieldName);
+                        if (!fieldName.equals(FieldDictionary.RECORD_ID)
+                                && !fieldName.equals(FieldDictionary.RECORD_TIME)
+                                && !fieldName.equals(FieldDictionary.RECORD_TYPE)) {
+                            // Keep mode
+                            if (!fieldsToKeep.contains(fieldName)) {
+                                record.removeField(fieldName);
+                            }
                         }
                     }
                 });

--- a/logisland-components/logisland-processors/logisland-processor-common/src/test/java/com/hurence/logisland/processor/RemoveFieldsTest.java
+++ b/logisland-components/logisland-processors/logisland-processor-common/src/test/java/com/hurence/logisland/processor/RemoveFieldsTest.java
@@ -134,8 +134,7 @@ public class RemoveFieldsTest extends BaseSyslogTest {
 
         Record record1 = getRecord1();
         TestRunner testRunner = TestRunners.newTestRunner(new RemoveFields());
-        // Keep record_type otherwise cannot get outputRecord
-        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string1,"+ FieldDictionary.RECORD_TYPE);
+        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string1");
         testRunner.assertValid();
         testRunner.enqueue(record1);
         testRunner.run();
@@ -156,8 +155,7 @@ public class RemoveFieldsTest extends BaseSyslogTest {
 
         Record record1 = getRecord1();
         TestRunner testRunner = TestRunners.newTestRunner(new RemoveFields());
-        // Keep record_type otherwise cannot get outputRecord
-        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string1,long1,"+ FieldDictionary.RECORD_TYPE);
+        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string1,long1");
         testRunner.assertValid();
         testRunner.enqueue(record1);
         testRunner.run();
@@ -179,8 +177,7 @@ public class RemoveFieldsTest extends BaseSyslogTest {
 
         Record record1 = getRecord1();
         TestRunner testRunner = TestRunners.newTestRunner(new RemoveFields());
-        // Keep record_type otherwise cannot get outputRecord
-        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string3,"+ FieldDictionary.RECORD_TYPE);
+        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string3");
         testRunner.assertValid();
         testRunner.enqueue(record1);
         testRunner.run();
@@ -200,8 +197,7 @@ public class RemoveFieldsTest extends BaseSyslogTest {
     public void testKeepTwiceAfield() throws FileNotFoundException, IOException, ParseException, URISyntaxException {
         Record record1 = getRecord1();
         TestRunner testRunner = TestRunners.newTestRunner(new RemoveFields());
-        // Keep record_type otherwise cannot get outputRecord
-        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string1,string1,"+ FieldDictionary.RECORD_TYPE);
+        testRunner.setProperty(RemoveFields.FIELDS_TO_KEEP, "string1,string1");
         testRunner.assertValid();
         testRunner.enqueue(record1);
         testRunner.run();


### PR DESCRIPTION
The RemoveFields processor can now remove fields by removing all fields but a provided keep list.