### PR TITLE
Feature/mongodb conditional updates

### DIFF
--- a/logisland-assembly/pom.xml
+++ b/logisland-assembly/pom.xml
@@ -133,12 +133,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>1.7.7</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.esotericsoftware.kryo</groupId>
                 <artifactId>kryo</artifactId>
                 <version>2.21</version>

--- a/logisland-components/logisland-processors/logisland-processor-common/pom.xml
+++ b/logisland-components/logisland-processors/logisland-processor-common/pom.xml
@@ -77,13 +77,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>1.8.2</version>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.9.9</version>

--- a/logisland-components/logisland-processors/logisland-processor-common/pom.xml
+++ b/logisland-components/logisland-processors/logisland-processor-common/pom.xml
@@ -90,9 +90,6 @@
             <scope>test</scope>
         </dependency>
 
-
-
-
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/ExpandMapFields.java
+++ b/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/ExpandMapFields.java
@@ -1,0 +1,116 @@
+/*
+ *  * Copyright (C) 2018 Hurence (support@hurence.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hurence.logisland.processor;
+
+import com.hurence.logisland.annotation.documentation.CapabilityDescription;
+import com.hurence.logisland.annotation.documentation.Tags;
+import com.hurence.logisland.component.AllowableValue;
+import com.hurence.logisland.component.PropertyDescriptor;
+import com.hurence.logisland.record.Field;
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.validator.StandardValidators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+@Tags({"record", "fields", "Expand", "Map"})
+@CapabilityDescription("Expands the content of a MAP field to the root.")
+public class ExpandMapFields extends AbstractProcessor {
+
+    public static final PropertyDescriptor FIELDS_TO_EXPAND = new PropertyDescriptor.Builder()
+            .name("fields.to.expand")
+            .required(true)
+            .addValidator(StandardValidators.COMMA_SEPARATED_LIST_VALIDATOR)
+            .displayName("Fields to expand")
+            .description("Comma separated list of fields of type map that will be expanded to the root")
+            .build();
+
+    private static final Logger logger = LoggerFactory.getLogger(AddFields.class);
+
+
+    public static final AllowableValue OVERWRITE_EXISTING =
+            new AllowableValue("overwrite_existing", "overwrite existing field", "if field already exist");
+
+    public static final AllowableValue KEEP_OLD_FIELD =
+            new AllowableValue("keep_only_old_field", "keep only old field value", "keep only old field");
+
+
+    public static final PropertyDescriptor CONFLICT_RESOLUTION_POLICY = new PropertyDescriptor.Builder()
+            .name("conflict.resolution.policy")
+            .description("What to do when a field with the same name already exists ?")
+            .required(false)
+            .defaultValue(KEEP_OLD_FIELD.getValue())
+            .allowableValues(OVERWRITE_EXISTING, KEEP_OLD_FIELD)
+            .build();
+
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Arrays.asList(FIELDS_TO_EXPAND, CONFLICT_RESOLUTION_POLICY);
+    }
+
+    @Override
+    public Collection<Record> process(ProcessContext context, Collection<Record> records) {
+        final List<String> fieldNames = Arrays.asList(context.getPropertyValue(FIELDS_TO_EXPAND).asString().split(","));
+        boolean overwrite = OVERWRITE_EXISTING.getValue().equals(context.getPropertyValue(CONFLICT_RESOLUTION_POLICY).asString());
+        records.forEach(record ->
+                fieldNames.forEach(fieldName -> {
+                    if (record.hasField(fieldName)) {
+                        Field field = record.removeField(fieldName);
+                        if (field.getType() == FieldType.MAP && field.getRawValue() instanceof Map) {
+                            ((Map<String, ?>) field.getRawValue()).forEach((k, v) -> {
+                                if (overwrite || !record.hasField(k)) {
+                                    record.setField(doDeserializeField(k, v));
+                                }
+                            });
+                        }
+                    }
+                }));
+        return records;
+    }
+
+    private Field doDeserializeField(String name, Object value) {
+        Field ret;
+        if (value == null) {
+            ret = new Field(name, FieldType.NULL, null);
+        } else if (value instanceof List) {
+            ret = new Field(name, FieldType.ARRAY, value);
+        } else if (value instanceof Map) {
+            ret = new Field(name, FieldType.MAP, value);
+        } else {
+            if (value instanceof Boolean) {
+                ret = new Field(name, FieldType.BOOLEAN, value);
+            } else if (value instanceof Float) {
+                ret = new Field(name, FieldType.FLOAT, value);
+            } else if (value instanceof Long) {
+                ret = new Field(name, FieldType.LONG, value);
+            } else if (value instanceof Number) {
+                ret = new Field(name, FieldType.INT, value);
+            } else if (value instanceof Double) {
+                ret = new Field(name, FieldType.DOUBLE, value);
+            } else if (value instanceof Date) {
+                ret = new Field(name, FieldType.DATETIME, value);
+            } else {
+                ret = new Field(name, FieldType.STRING, value);
+            }
+        }
+        return ret;
+    }
+}

--- a/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/GenerateRandomRecord.java
+++ b/logisland-components/logisland-processors/logisland-processor-common/src/main/java/com/hurence/logisland/processor/GenerateRandomRecord.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Hurence (support@hurence.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,21 +18,17 @@ package com.hurence.logisland.processor;
 import com.hurence.logisland.annotation.documentation.CapabilityDescription;
 import com.hurence.logisland.annotation.documentation.Tags;
 import com.hurence.logisland.component.PropertyDescriptor;
-import com.hurence.logisland.record.FieldDictionary;
-import com.hurence.logisland.record.FieldType;
 import com.hurence.logisland.record.Record;
-import com.hurence.logisland.record.StandardRecord;
-import com.hurence.logisland.serializer.AvroSerializer;
 import com.hurence.logisland.util.avro.eventgenerator.DataGenerator;
 import com.hurence.logisland.validator.StandardValidators;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.math3.random.RandomDataGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 @Tags({"record", "avro", "generator"})
 @CapabilityDescription("This is a processor that make random records given an Avro schema")
@@ -73,12 +69,9 @@ public class GenerateRandomRecord extends AbstractProcessor {
     public Collection<Record> process(final ProcessContext context, final Collection<Record> collection) {
 
         final String schemaContent = context.getPropertyValue(OUTPUT_SCHEMA).asString();
-        final Schema.Parser parser = new Schema.Parser();
-        final Schema schema = parser.parse(schemaContent);
 
         final DataGenerator dataGenerator = new DataGenerator(schemaContent);
         final RandomDataGenerator randomData = new RandomDataGenerator();
-        final AvroSerializer avroSerializer = new AvroSerializer(schema);
 
         final int minEventsCount = context.getPropertyValue(MIN_EVENTS_COUNT).asInteger();
         final int maxEventsCount = context.getPropertyValue(MAX_EVENTS_COUNT).asInteger();
@@ -89,80 +82,7 @@ public class GenerateRandomRecord extends AbstractProcessor {
 
         for (int i = 0; i < eventsCount; i++) {
             try {
-                GenericRecord eventRecord = dataGenerator.generateRandomRecord();
-
-                Record record = new StandardRecord(RECORD_TYPE);
-
-
-                for (final Schema.Field schemaField : schema.getFields()) {
-
-                    final String fieldName = schemaField.name();
-                    final Object fieldValue = eventRecord.get(fieldName);
-                    final FieldType fieldType;
-                    {
-                        /**
-                         * currently all avro type are : RECORD,ENUM,ARRAY,MAP,UNION,FIXED,STRING,BYTES,INT,LONG,FLOAT,DOUBLE,BOOLEAN,NULL;
-                         * all LogIsland type are : RECORD,ENUM,ARRAY,MAP,STRING,BYTES,INT,LONG,FLOAT,DOUBLE,BOOLEAN,NULL;
-                         *
-                         * So we lack of types: UNION, FIXED
-                         */
-                        Schema.Type avroType = schemaField.schema().getType();
-                        switch (avroType) {
-                            case UNION:
-                                List<Schema> schemas = schemaField.schema().getTypes();
-                                List<Schema.Type> types = new LinkedList<>();
-                                for (Schema schemaF2 : schemas) {
-                                    types.add(schemaF2.getType());
-                                }
-
-                                if (types.size() > 2 || !types.contains(Schema.Type.NULL)) {
-                                    throw new UnsupportedOperationException(
-                                            "avro schema with types UNION with another format than '['null', 'atype']' is not yet supported"
-                                    );
-                                }
-                                Schema.Type determineType = null;
-                                for (Schema.Type type : types) {
-                                    switch (type) {
-                                        case NULL:
-                                            break;
-                                        default:
-                                            determineType = type;
-                                            break;
-                                    }
-                                }
-                                if (determineType == null) {
-                                    throw new UnsupportedOperationException("UNION of null type makes no sense");
-                                }
-                                fieldType = FieldType.valueOf(determineType.getName().toUpperCase());
-                                break;
-                            case FIXED:
-                                //TODO verify this is a correct behaviour
-                                fieldType = FieldType.STRING;
-                                break;
-                            default:
-                                fieldType = FieldType.valueOf(avroType.getName().toUpperCase());
-                                break;
-                        }
-                    }
-
-                    if (Objects.equals(fieldName, FieldDictionary.RECORD_ID)) {
-                        record.setId(fieldValue.toString());
-                    } else if (!Objects.equals(fieldName, FieldDictionary.RECORD_TYPE)) {
-                        if (fieldValue instanceof org.apache.avro.util.Utf8) {
-                            record.setStringField(fieldName, fieldValue.toString());
-                        } else if (fieldValue instanceof GenericData.Array) {
-                            GenericData.Array avroArray = (GenericData.Array) fieldValue;
-                            List<Object> list = new ArrayList<>();
-                            record.setField(fieldName, FieldType.ARRAY, list);
-                            AvroSerializer.copyArray(avroArray, list);
-                        } else {
-                            record.setField(fieldName, fieldType, fieldValue);
-                        }
-
-                    }
-                }
-
-                outRecords.add(record);
+                outRecords.add(dataGenerator.generateRandomRecord(RECORD_TYPE));
             } catch (Exception e) {
                 logger.error("problem while generating random event from avro schema {}", e);
             }

--- a/logisland-components/logisland-processors/logisland-processor-common/src/test/java/com/hurence/logisland/processor/ExpandMapFieldsTest.java
+++ b/logisland-components/logisland-processors/logisland-processor-common/src/test/java/com/hurence/logisland/processor/ExpandMapFieldsTest.java
@@ -1,0 +1,94 @@
+/*
+ *  * Copyright (C) 2018 Hurence (support@hurence.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hurence.logisland.processor;
+
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.record.StandardRecord;
+import com.hurence.logisland.util.runner.TestRunner;
+import com.hurence.logisland.util.runner.TestRunners;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExpandMapFieldsTest {
+
+    private Record createTestRecord() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("f1", new Date());
+        map.put("f2", 30L);
+        map.put("f3", Arrays.asList(1, 2, 3, 4));
+        map.put("f4", new HashMap<>());
+        map.put("f5", "Hello world");
+        Record ret = new StandardRecord("test");
+        ret.setField("f2", FieldType.STRING, "I will survive");
+        ret.setField("map", FieldType.MAP, map);
+        return ret;
+    }
+
+    @Test
+    public void testOverwriteValues() {
+        TestRunner runner = TestRunners.newTestRunner(new ExpandMapFields());
+        runner.setProperty(ExpandMapFields.CONFLICT_RESOLUTION_POLICY, ExpandMapFields.OVERWRITE_EXISTING);
+        runner.setProperty(ExpandMapFields.FIELDS_TO_EXPAND, "map");
+        runner.assertValid();
+        runner.enqueue(createTestRecord());
+        runner.run();
+        runner.assertOutputRecordsCount(1);
+        runner.assertAllRecords(record -> {
+            Assert.assertFalse(record.hasField("map"));
+            Assert.assertTrue(record.hasField("f1"));
+            Assert.assertTrue(record.hasField("f2"));
+            Assert.assertTrue(record.hasField("f3"));
+            Assert.assertTrue(record.hasField("f4"));
+            Assert.assertTrue(record.hasField("f5"));
+            Assert.assertEquals(record.getField("f1").getType(), FieldType.DATETIME);
+            Assert.assertEquals(record.getField("f2").getType(), FieldType.LONG);
+            Assert.assertEquals(record.getField("f3").getType(), FieldType.ARRAY);
+            Assert.assertEquals(record.getField("f4").getType(), FieldType.MAP);
+            Assert.assertEquals(record.getField("f5").getType(), FieldType.STRING);
+            Assert.assertEquals(record.getField("f5").getRawValue(), "Hello world");
+        });
+    }
+
+
+    @Test
+    public void testKeepOldValues() {
+        TestRunner runner = TestRunners.newTestRunner(new ExpandMapFields());
+        runner.setProperty(ExpandMapFields.CONFLICT_RESOLUTION_POLICY, ExpandMapFields.KEEP_OLD_FIELD);
+        runner.setProperty(ExpandMapFields.FIELDS_TO_EXPAND, "map");
+        runner.assertValid();
+        runner.enqueue(createTestRecord());
+        runner.run();
+        runner.assertOutputRecordsCount(1);
+        runner.assertAllRecords(record -> {
+            Assert.assertFalse(record.hasField("map"));
+            Assert.assertTrue(record.hasField("f1"));
+            Assert.assertTrue(record.hasField("f2"));
+            Assert.assertTrue(record.hasField("f3"));
+            Assert.assertTrue(record.hasField("f4"));
+            Assert.assertTrue(record.hasField("f5"));
+            Assert.assertEquals(record.getField("f2").getRawValue(), "I will survive");
+        });
+    }
+
+}

--- a/logisland-components/logisland-processors/logisland-processor-common/src/test/java/com/hurence/logisland/processor/ModifyIdTest.java
+++ b/logisland-components/logisland-processors/logisland-processor-common/src/test/java/com/hurence/logisland/processor/ModifyIdTest.java
@@ -24,7 +24,6 @@ import com.hurence.logisland.util.runner.MockRecord;
 import com.hurence.logisland.util.runner.TestRunner;
 import com.hurence.logisland.util.runner.TestRunners;
 import com.hurence.logisland.util.time.DateUtil;
-import org.apache.avro.Schema;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -230,10 +229,10 @@ public class ModifyIdTest {
     @Test
     public void testPerf() {
         Record record1 = getRecord1();
-        Schema schema = RecordSchemaUtil.generateSchema(record1);
+
 
         TestRunner generator = TestRunners.newTestRunner(new GenerateRandomRecord());
-        generator.setProperty(GenerateRandomRecord.OUTPUT_SCHEMA, schema.toString());
+        generator.setProperty(GenerateRandomRecord.OUTPUT_SCHEMA,  RecordSchemaUtil.generateSchema(record1).toString());
         generator.setProperty(GenerateRandomRecord.MIN_EVENTS_COUNT, "10000");
         generator.setProperty(GenerateRandomRecord.MAX_EVENTS_COUNT, "20000");
         generator.run();

--- a/logisland-components/logisland-services/logisland-service-mongodb/logisland-service-mongodb-client/src/main/java/com/hurence/logisland/service/mongodb/MongoDBUpdater.java
+++ b/logisland-components/logisland-services/logisland-service-mongodb/logisland-service-mongodb-client/src/main/java/com/hurence/logisland/service/mongodb/MongoDBUpdater.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Hurence (support@hurence.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,11 +16,10 @@
 package com.hurence.logisland.service.mongodb;
 
 import com.hurence.logisland.record.Record;
-import com.hurence.logisland.service.datastore.DatastoreClientService;
 import com.hurence.logisland.util.Tuple;
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import org.bson.Document;
@@ -31,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 
@@ -39,18 +39,15 @@ import java.util.stream.Collectors;
  */
 public class MongoDBUpdater implements Runnable {
 
-
+    private static volatile int threadCount = 0;
     private final BlockingQueue<Tuple<Record, Bson>> records;
     private final int batchSize;
     private final long flushInterval;
-    private volatile int batchedUpdates = 0;
-    private volatile long lastTS = 0;
+    private long lastTS = 0;
     private final String bulkMode;
-
     private final MongoDatabase db;
     private final MongoCollection<Document> col;
 
-    private static volatile int threadCount = 0;
 
     private Logger logger = LoggerFactory.getLogger(MongoDBUpdater.class.getName() + threadCount);
 
@@ -76,45 +73,54 @@ public class MongoDBUpdater implements Runnable {
         List<Tuple<Document, Bson>> batchBuffer = new ArrayList<>();
 
         while (true) {
-
-            // process record if one
             try {
-                Tuple<Record, Bson> record = records.take();
+                Tuple<Record, Bson> record = records.poll(flushInterval, TimeUnit.MILLISECONDS);
                 if (record != null) {
                     batchBuffer.add(new Tuple<>(RecordConverter.convert(record.getKey()), record.getValue()));
-                    batchedUpdates++;
                 }
+                long currentTS = System.nanoTime();
+                if (batchBuffer.size() > 0 &&
+                        ((currentTS - lastTS) >= flushInterval * 1000000 || batchBuffer.size() >= batchSize)) {
+                    //use moustache operator to avoid composing strings when not needed
+                    logger.debug("committing {} records to Mongo after {} ns", batchBuffer.size(), (currentTS - lastTS));
+
+                    if (MongoDBControllerService.BULK_MODE_UPSERT.getValue().equals(bulkMode)) {
+                        ReplaceOptions replaceOptions = new ReplaceOptions().upsert(true);
+                        //split batches by 500 document each max
+                        for (int i = 0; i < batchBuffer.size(); i+=500) {
+                            try {
+                                col.bulkWrite(batchBuffer.stream().skip(i).limit(500)
+                                        .map(document -> new ReplaceOneModel<>(
+                                                document.getValue(),
+                                                document.getKey(),
+                                                replaceOptions)).collect(Collectors.toList()));
+                            } catch (MongoBulkWriteException bwe) {
+                                bwe.getWriteErrors().forEach(error -> {
+                                    if (error.getCode() != 11000) {
+                                        logger.warn("MongoDB updater got error: {}", error);
+                                    }
+                                });
+                            }
+                        }
+                    } else {
+                        col.insertMany(batchBuffer.stream().map(Tuple::getKey).collect(Collectors.toList()));
+                    }
+                    lastTS = currentTS;
+                    batchBuffer = new ArrayList<>();
+                }
+
             } catch (InterruptedException e) {
                 //here we should exit the loop
-                logger.warn("Interrupted while waiting", e);
+                logger.info("Interrupted while waiting: {}", e.getMessage());
                 break;
-            }
-
-            //
-            long currentTS = System.nanoTime();
-            if ((currentTS - lastTS) >= flushInterval * 1000000 || batchedUpdates >= batchSize) {
-                //use moustache operator to avoid composing strings when not needed
-                logger.debug("committing {} records to Mongo after {} ns", batchedUpdates, (currentTS - lastTS));
-
-                if (MongoDBControllerService.BULK_MODE_UPSERT.getValue().equals(bulkMode)) {
-                    ReplaceOptions replaceOptions = new ReplaceOptions().upsert(true);
-                    col.bulkWrite(batchBuffer.stream().map(document -> new ReplaceOneModel<>(
-                            document.getValue(),
-                            document.getKey(),
-                            replaceOptions)).collect(Collectors.toList()));
-                } else {
-                    col.insertMany(batchBuffer.stream().map(Tuple::getKey).collect(Collectors.toList()));
-                }
-
-                lastTS = currentTS;
-                batchBuffer = new ArrayList<>();
-                batchedUpdates = 0;
+            } catch (Exception e) {
+                logger.error("Unrecoverable error from MongoDB updater. Loosing data!", e);
+                batchBuffer.clear();
+                lastTS = System.nanoTime();
             }
         }
-
-
-        // Thread.sleep(10);
     }
+
 }
 
 

--- a/logisland-components/logisland-services/logisland-service-mongodb/logisland-service-mongodb-client/src/main/java/com/hurence/logisland/service/mongodb/RecordConverter.java
+++ b/logisland-components/logisland-services/logisland-service-mongodb/logisland-service-mongodb-client/src/main/java/com/hurence/logisland/service/mongodb/RecordConverter.java
@@ -56,10 +56,7 @@ public class RecordConverter {
         Document document = new Document("_id", record.getId());
 
         record.getFieldsEntrySet().forEach(entry -> {
-
             document.put(entry.getKey(), entry.getValue().getRawValue());
-
-
 
         });
 

--- a/logisland-components/logisland-services/logisland-service-redis/src/main/java/com/hurence/logisland/redis/service/RedisKeyValueCacheService.java
+++ b/logisland-components/logisland-services/logisland-service-redis/src/main/java/com/hurence/logisland/redis/service/RedisKeyValueCacheService.java
@@ -36,7 +36,6 @@ import com.hurence.logisland.util.Tuple;
 import com.hurence.logisland.validator.StandardValidators;
 import com.hurence.logisland.validator.ValidationContext;
 import com.hurence.logisland.validator.ValidationResult;
-import org.apache.avro.Schema;
 import org.apache.commons.io.IOUtils;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.Cursor;
@@ -334,9 +333,7 @@ public class RedisKeyValueCacheService extends AbstractControllerService impleme
     private RecordSerializer getSerializer(String inSerializerClass, String schemaContent) {
 
         if (inSerializerClass.equals(AVRO_SERIALIZER.getValue())) {
-            Schema.Parser parser = new Schema.Parser();
-            Schema inSchema = parser.parse(schemaContent);
-            new AvroSerializer(inSchema);
+            return new AvroSerializer(schemaContent);
         } else if (inSerializerClass.equals(JSON_SERIALIZER.getValue())) {
             return new JsonSerializer();
         } else if (inSerializerClass.equals(BYTESARRAY_SERIALIZER.getValue())) {

--- a/logisland-core/logisland-api/src/main/java/com/hurence/logisland/controller/StandardControllerServiceContext.java
+++ b/logisland-core/logisland-api/src/main/java/com/hurence/logisland/controller/StandardControllerServiceContext.java
@@ -52,7 +52,7 @@ public class StandardControllerServiceContext extends AbstractConfiguredComponen
         final String setPropertyValue = getProperty(descriptor);
         final String propValue = (setPropertyValue == null) ? descriptor.getDefaultValue() : setPropertyValue;
 
-        return new StandardPropertyValue(propValue);
+        return PropertyValueFactory.getInstance(descriptor, propValue, getControllerServiceLookup());
     }
 
     @Override

--- a/logisland-core/logisland-api/src/main/java/com/hurence/logisland/record/Field.java
+++ b/logisland-core/logisland-api/src/main/java/com/hurence/logisland/record/Field.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -153,6 +154,8 @@ public class Field implements PropertyValue, Serializable {
         } else {
             if (rawValue instanceof Number) {
                 return ((Number) rawValue).longValue();
+            } else if (rawValue instanceof Date) {
+              return ((Date) rawValue).getTime();
             } else {
                 try {
                     return Long.parseLong(rawValue.toString());

--- a/logisland-core/logisland-api/src/main/java/com/hurence/logisland/record/FieldType.java
+++ b/logisland-core/logisland-api/src/main/java/com/hurence/logisland/record/FieldType.java
@@ -34,7 +34,8 @@ public enum FieldType {
     MAP,
     ENUM,
     BOOLEAN,
-    UNION;
+    UNION,
+    DATETIME;
 
     public String toString() {
         return name;

--- a/logisland-core/logisland-api/src/main/java/com/hurence/logisland/service/datastore/DatastoreClientService.java
+++ b/logisland-core/logisland-api/src/main/java/com/hurence/logisland/service/datastore/DatastoreClientService.java
@@ -55,20 +55,6 @@ public interface DatastoreClientService extends ControllerService {
             .defaultValue("5")
             .build();
 
-    AllowableValue BULK_MODE_INSERT = new AllowableValue("insert", "Insert", "Insert records whose key must be unique");
-    AllowableValue BULK_MODE_UPSERT = new AllowableValue("upsert", "Insert or Update",
-            "Insert records if not already existing or update the record if already existing");
-
-
-    PropertyDescriptor BULK_MODE = new PropertyDescriptor.Builder()
-            .name("bulk.mode")
-            .description("Bulk mode (insert or upsert)")
-            .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .allowableValues(BULK_MODE_INSERT, BULK_MODE_UPSERT)
-            .defaultValue(BULK_MODE_INSERT.getValue())
-            .build();
-
 
     /* ********************************************************************
      * Collection handling section

--- a/logisland-core/logisland-engines/logisland-engine-spark_1_6/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamDebugger.scala
+++ b/logisland-core/logisland-engines/logisland-engine-spark_1_6/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamDebugger.scala
@@ -137,8 +137,8 @@ class KafkaRecordStreamDebugger extends AbstractKafkaRecordStream {
                     if (streamContext.getPropertyValue(AbstractKafkaRecordStream.AVRO_OUTPUT_SCHEMA).isSet) {
                         try {
                             val strSchema = streamContext.getPropertyValue(AbstractKafkaRecordStream.AVRO_OUTPUT_SCHEMA).asString()
-                            val parser = new Schema.Parser
-                            val schema = parser.parse(strSchema)
+                            val schema = RecordSchemaUtil.compileSchema(strSchema)
+
 
                             outgoingEvents = outgoingEvents.map(record => RecordSchemaUtil.convertToValidRecord(record, schema))
                         } catch {

--- a/logisland-core/logisland-engines/logisland-engine-spark_1_6/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamParallelProcessing.scala
+++ b/logisland-core/logisland-engines/logisland-engine-spark_1_6/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamParallelProcessing.scala
@@ -208,8 +208,8 @@ class KafkaRecordStreamParallelProcessing extends AbstractKafkaRecordStream {
                         if (streamContext.getPropertyValue(AbstractKafkaRecordStream.AVRO_OUTPUT_SCHEMA).isSet) {
                             try {
                                 val strSchema = streamContext.getPropertyValue(AbstractKafkaRecordStream.AVRO_OUTPUT_SCHEMA).asString()
-                                val parser = new Schema.Parser
-                                val schema = parser.parse(strSchema)
+                                val schema = RecordSchemaUtil.compileSchema(strSchema)
+
 
                                 outgoingEvents = outgoingEvents.map(record => RecordSchemaUtil.convertToValidRecord(record, schema))
                             } catch {

--- a/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamDebugger.scala
+++ b/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamDebugger.scala
@@ -142,8 +142,8 @@ class KafkaRecordStreamDebugger extends AbstractKafkaRecordStream {
                     if (streamContext.getPropertyValue(AVRO_OUTPUT_SCHEMA).isSet) {
                         try {
                             val strSchema = streamContext.getPropertyValue(AVRO_OUTPUT_SCHEMA).asString()
-                            val parser = new Schema.Parser
-                            val schema = parser.parse(strSchema)
+                            val schema = RecordSchemaUtil.compileSchema(strSchema)
+
 
                             outgoingEvents = outgoingEvents.map(record => RecordSchemaUtil.convertToValidRecord(record, schema))
                         } catch {

--- a/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamParallelProcessing.scala
+++ b/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/KafkaRecordStreamParallelProcessing.scala
@@ -167,8 +167,7 @@ class KafkaRecordStreamParallelProcessing extends AbstractKafkaRecordStream {
                         if (streamContext.getPropertyValue(AVRO_OUTPUT_SCHEMA).isSet) {
                             try {
                                 val strSchema = streamContext.getPropertyValue(AVRO_OUTPUT_SCHEMA).asString()
-                                val parser = new Schema.Parser
-                                val schema = parser.parse(strSchema)
+                                val schema = RecordSchemaUtil.compileSchema(strSchema)
 
                                 outgoingEvents = outgoingEvents.map(record => RecordSchemaUtil.convertToValidRecord(record, schema))
                             } catch {

--- a/logisland-core/logisland-framework/logisland-resources/src/main/resources/docs/components.rst
+++ b/logisland-core/logisland-framework/logisland-resources/src/main/resources/docs/components.rst
@@ -1139,6 +1139,38 @@ In the list below, the names of required properties appear in **bold**. Any othe
 
 ----------
 
+.. _com.hurence.logisland.processor.ExpandMapFields: 
+
+ExpandMapFields
+---------------
+Expands the content of a MAP field to the root.
+
+Module
+______
+com.hurence.logisland:logisland-processor-common:1.0.0-RC1
+
+Class
+_____
+com.hurence.logisland.processor.ExpandMapFields
+
+Tags
+____
+record, fields, Expand, Map
+
+Properties
+__________
+In the list below, the names of required properties appear in **bold**. Any other properties (not in bold) are considered optional. The table also indicates any default values
+.
+
+.. csv-table:: allowable-values
+   :header: "Name","Description","Allowable Values","Default Value","Sensitive","EL"
+   :widths: 20,60,30,20,10,10
+
+   "**fields.to.expand**", "Comma separated list of fields of type map that will be expanded to the root", "", "null", "", ""
+   "conflict.resolution.policy", "What to do when a field with the same name already exists ?", "overwrite existing field (if field already exist), keep only old field value (keep only old field)", "keep_only_old_field", "", ""
+
+----------
+
 .. _com.hurence.logisland.processor.hbase.FetchHBaseRow: 
 
 FetchHBaseRow
@@ -1595,9 +1627,10 @@ In the list below, the names of required properties appear in **bold**. Any othe
    "**mongo.collection.name**", "The name of the collection to use", "", "null", "", "**true**"
    "batch.size", "The preferred number of Records to setField to the database in a single transaction", "", "1000", "", ""
    "bulk.size", "bulk size in MB", "", "5", "", ""
-   "bulk.mode", "Bulk mode (insert or upsert)", "Insert (Insert records whose key must be unique), Insert or Update (Insert records if not already existing or update the record if already existing)", "insert", "", ""
+   "mongo.bulk.mode", "Bulk mode (insert or upsert)", "Insert (Insert records whose key must be unique), Insert or Update (Insert records if not already existing or update the record if already existing)", "insert", "", ""
    "flush.interval", "flush interval in ms", "", "500", "", ""
    "**mongo.write.concern**", "The write concern to use", "ACKNOWLEDGED, UNACKNOWLEDGED, FSYNCED, JOURNALED, REPLICA_ACKNOWLEDGED, MAJORITY", "ACKNOWLEDGED", "", ""
+   "mongo.bulk.upsert.condition", "A custom condition for the bulk upsert (Filter for the bulkwrite). If not specified the standard condition is to match same id ('_id': data._id)", "", "${'{ "_id" :"' + record_id + '"}'}", "", "**true**"
 
 ----------
 

--- a/logisland-core/logisland-framework/logisland-scripting/logisland-scripting-mvel/src/main/java/com/hurence/logisland/jsr223/mvel/MvelCompiledScript.java
+++ b/logisland-core/logisland-framework/logisland-scripting/logisland-scripting-mvel/src/main/java/com/hurence/logisland/jsr223/mvel/MvelCompiledScript.java
@@ -25,6 +25,8 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
 
 public class MvelCompiledScript extends CompiledScript {
 
@@ -41,14 +43,15 @@ public class MvelCompiledScript extends CompiledScript {
 		if (this.expression.length()==0) {
 			throw new IllegalArgumentException("expression should not be empty" );
 		}
-		this.compiledExpression = MVEL.compileExpression(this.expression);
+		this.compiledExpression = MVEL.compileGetExpression(this.expression);
 	}
 	
 	@Override
 	public Object eval(ScriptContext context) throws ScriptException {
 		try {
 			Bindings map = context.getBindings(ScriptContext.ENGINE_SCOPE);
-			return MVEL.executeExpression(compiledExpression, map);
+			VariableResolverFactory functionFactory = new MapVariableResolverFactory(map);
+			return MVEL.executeExpression(compiledExpression, map, functionFactory);
 		}
 		catch (Throwable t) {
 			return null;

--- a/logisland-core/logisland-framework/logisland-scripting/logisland-scripting-mvel/src/main/java/com/hurence/logisland/jsr223/mvel/MvelCompiledScript.java
+++ b/logisland-core/logisland-framework/logisland-scripting/logisland-scripting-mvel/src/main/java/com/hurence/logisland/jsr223/mvel/MvelCompiledScript.java
@@ -16,6 +16,8 @@
 package com.hurence.logisland.jsr223.mvel;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Objects;
 
 import javax.script.Bindings;
@@ -25,6 +27,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.mvel2.MVEL;
+import org.mvel2.compiler.ExpressionCompiler;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.MapVariableResolverFactory;
 
@@ -43,15 +46,14 @@ public class MvelCompiledScript extends CompiledScript {
 		if (this.expression.length()==0) {
 			throw new IllegalArgumentException("expression should not be empty" );
 		}
-		this.compiledExpression = MVEL.compileGetExpression(this.expression);
+		this.compiledExpression = new ExpressionCompiler(this.expression).compile();
 	}
 	
 	@Override
 	public Object eval(ScriptContext context) throws ScriptException {
 		try {
 			Bindings map = context.getBindings(ScriptContext.ENGINE_SCOPE);
-			VariableResolverFactory functionFactory = new MapVariableResolverFactory(map);
-			return MVEL.executeExpression(compiledExpression, map, functionFactory);
+			return MVEL.executeExpression(compiledExpression, Collections.unmodifiableMap(new HashMap<>(map)));
 		}
 		catch (Throwable t) {
 			return null;

--- a/logisland-core/logisland-framework/logisland-scripting/logisland-scripting-mvel/src/test/java/com/hurence/logisland/jsr223/mvel/TestMvelEngine.java
+++ b/logisland-core/logisland-framework/logisland-scripting/logisland-scripting-mvel/src/test/java/com/hurence/logisland/jsr223/mvel/TestMvelEngine.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Hurence (support@hurence.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,33 +15,48 @@
  */
 package com.hurence.logisland.jsr223.mvel;
 
-import static org.junit.Assert.*;
-
-import java.util.HashMap;
-import java.util.Map;
+import com.hurence.logisland.jsr223.BindingsImpl;
+import org.junit.Test;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.junit.Test;
-
-import com.hurence.logisland.jsr223.BindingsImpl;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class TestMvelEngine {
 
-	@Test
-	public void test() {
-		ScriptEngineManager sem = new ScriptEngineManager();
-		ScriptEngine se = sem.getEngineByName("mvel");
-		Map<String, Object> model = new HashMap<>();
-		model.put("property", "value 1");
-		try {
-			Object result = se.eval("property", new BindingsImpl(model));
-			assertNotNull("value 1", result);
-		}
-		catch (Exception e) {
-			fail();
-		}
-	}
-	
+    @Test
+    public void test() {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("mvel");
+        Map<String, Object> model = new HashMap<>();
+        model.put("property", "value 1");
+        model.put("myMap", Collections.singletonMap("k", "v"));
+        try {
+            Object result = se.eval("property", new BindingsImpl(model));
+            assertNotNull("value 1", result);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMapAccess() throws Exception {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("mvel");
+        Map<String, Object> model = new HashMap<>();
+        model.put("myMap", Collections.singletonMap("k", "v"));
+
+        Object result = se.eval("myMap['k']", new BindingsImpl(model));
+        assertEquals("v", result);
+
+
+    }
+
+
 }

--- a/logisland-core/logisland-framework/logisland-utils/pom.xml
+++ b/logisland-core/logisland-framework/logisland-utils/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
+            <version>1.8.2</version>
         </dependency>
         <dependency>
             <groupId>com.esotericsoftware.kryo</groupId>
@@ -172,6 +173,61 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.immutables.tools</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.avro:avro</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/license/**</exclude>
+                                        <exclude>META-INF/*</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <exclude>NOTICE</exclude>
+                                        <exclude>/*.txt</exclude>
+                                        <exclude>build.properties</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Change>GIT commit ID</Change>
+                                        <Build-Date>${maven.build.timestamp}</Build-Date>
+                                    </manifestEntries>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.avro</pattern>
+                                    <shadedPattern>logisland.repackaged.org.apache.avro</shadedPattern>
+                                </relocation>
+
+                            </relocations>
+
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/serializer/ExtendedJsonSerializer.java
+++ b/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/serializer/ExtendedJsonSerializer.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Hurence (support@hurence.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,13 +15,14 @@
  */
 package com.hurence.logisland.serializer;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hurence.logisland.record.Field;
 import com.hurence.logisland.record.FieldType;
 import com.hurence.logisland.record.Record;
 import com.hurence.logisland.record.StandardRecord;
+import com.hurence.logisland.util.time.DateUtil;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
 import java.text.DateFormat;
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 
 /**
@@ -65,47 +69,69 @@ public class ExtendedJsonSerializer implements RecordSerializer {
                 map.put(name, null);
             } else {
                 final Schema currentSchema = field != null ? field.schema() : schema;
-                switch (currentSchema.getType()) {
-                    case FLOAT:
-                        map.put(name, Float.parseFloat(value.toString()));
-                        break;
-                    case LONG:
-                        map.put(name, Long.parseLong(value.toString()));
-                        break;
-                    case ARRAY:
-                        final Map<String, Object> tmpMap = new LinkedHashMap<>();
-                        Object[] filtered = ((List<Object>) value).stream().map(o -> {
-                            tmpMap.clear();
-                            doFilter(tmpMap, null, o, currentSchema.getElementType());
-                            return tmpMap.get(null);
-                        }).toArray();
-                        map.put(name, filtered);
-                        break;
-                    case INT:
-                        map.put(name, Integer.parseInt(value.toString()));
-                        break;
-                    case DOUBLE:
-                        map.put(name, Double.parseDouble(value.toString()));
-                        break;
-                    case BOOLEAN:
-                        map.put(name, Boolean.parseBoolean(value.toString()));
-                        break;
-                    case MAP:
-                        Map<String, Object> tmpStruct = new LinkedHashMap<>();
-                        ((Map<String, Object>) value).forEach((k, v) -> doFilter(tmpStruct, k, v, currentSchema.getValueType()));
-                        map.put(name, tmpStruct);
-                        break;
-                    case RECORD:
-                        Map<String, Object> tmpRecord = new LinkedHashMap<>();
-                        ((Map<String, Object>) value).forEach((k, v) -> doFilter(tmpRecord, k, v, currentSchema));
-                        map.put(name, tmpRecord);
-                        break;
-                    default:
-                        map.put(name, value.toString());
-                        break;
+                LogicalType logicalType = currentSchema.getLogicalType();
+                if (logicalType instanceof LogicalTypes.Date ||
+                        logicalType instanceof LogicalTypes.TimestampMillis) {
+                    if (value instanceof Number) {
+                        map.put(name, new Date(((Number) value).longValue()));
+                    } else {
+                        try {
+                            map.put(name, new Date(Instant.parse(value.toString()).toEpochMilli()));
+                        } catch (DateTimeParseException ignored) {
+                            try {
+                                //falling back to logisland date parser
+                                map.put(name, DateUtil.parse(value.toString()));
+                            } catch (ParseException pe) {
+                                logger.warn("Error converting field {} with value {} to date : {}",
+                                        field.name(), value, pe.getMessage());
+                            }
+                        }
+                    }
+
+                } else {
+                    switch (currentSchema.getType()) {
+                        case FLOAT:
+                            map.put(name, Float.parseFloat(value.toString()));
+                            break;
+                        case LONG:
+                            map.put(name, Long.parseLong(value.toString()));
+                            break;
+                        case ARRAY:
+                            final Map<String, Object> tmpMap = new LinkedHashMap<>();
+                            Object[] filtered = ((List<Object>) value).stream().map(o -> {
+                                tmpMap.clear();
+                                doFilter(tmpMap, null, o, currentSchema.getElementType());
+                                return tmpMap.get(null);
+                            }).toArray();
+                            map.put(name, filtered);
+                            break;
+                        case INT:
+                            map.put(name, Integer.parseInt(value.toString()));
+                            break;
+                        case DOUBLE:
+                            map.put(name, Double.parseDouble(value.toString()));
+                            break;
+                        case BOOLEAN:
+                            map.put(name, Boolean.parseBoolean(value.toString()));
+                            break;
+                        case MAP:
+                            Map<String, Object> tmpStruct = new LinkedHashMap<>();
+                            ((Map<String, Object>) value).forEach((k, v) -> doFilter(tmpStruct, k, v, currentSchema.getValueType()));
+                            map.put(name, tmpStruct);
+                            break;
+                        case RECORD:
+                            Map<String, Object> tmpRecord = new LinkedHashMap<>();
+                            ((Map<String, Object>) value).forEach((k, v) -> doFilter(tmpRecord, k, v, currentSchema));
+                            map.put(name, tmpRecord);
+                            break;
+                        default:
+                            map.put(name, value.toString());
+                            break;
+                    }
                 }
             }
         }
+
     }
 
     public Map<String, Object> filterWithSchema(Map<String, Object> in) {
@@ -179,7 +205,7 @@ public class ExtendedJsonSerializer implements RecordSerializer {
             } else if (value instanceof Double) {
                 ret = new Field(name, FieldType.DOUBLE, value);
             } else if (value instanceof Date) {
-                ret = new Field(name, FieldType.LONG, ((Date) value).getTime());
+                ret = new Field(name, FieldType.DATETIME, value);
             } else {
                 ret = new Field(name, FieldType.STRING, value);
             }

--- a/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/serializer/ExtendedJsonSerializer.java
+++ b/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/serializer/ExtendedJsonSerializer.java
@@ -36,6 +36,7 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Basic but complete Json {@link RecordSerializer}.
@@ -98,11 +99,11 @@ public class ExtendedJsonSerializer implements RecordSerializer {
                             break;
                         case ARRAY:
                             final Map<String, Object> tmpMap = new LinkedHashMap<>();
-                            Object[] filtered = ((List<Object>) value).stream().map(o -> {
+                            List<Object> filtered = ((List<Object>) value).stream().map(o -> {
                                 tmpMap.clear();
                                 doFilter(tmpMap, null, o, currentSchema.getElementType());
                                 return tmpMap.get(null);
-                            }).toArray();
+                            }).collect(Collectors.toList());
                             map.put(name, filtered);
                             break;
                         case INT:

--- a/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/serializer/ExtendedJsonSerializer.java
+++ b/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/serializer/ExtendedJsonSerializer.java
@@ -147,7 +147,7 @@ public class ExtendedJsonSerializer implements RecordSerializer {
 
     public ExtendedJsonSerializer(String schemaString) {
         if (schemaString != null) {
-            final Schema.Parser parser = new Schema.Parser();
+            final Schema.Parser parser = new Schema.Parser().setValidate(false);
             try {
                 schema = parser.parse(schemaString);
             } catch (Exception e) {

--- a/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/avro/eventgenerator/DataGenerator.java
+++ b/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/avro/eventgenerator/DataGenerator.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Hurence (support@hurence.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,9 +31,14 @@ package com.hurence.logisland.util.avro.eventgenerator;
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 
 
+import com.hurence.logisland.record.FieldDictionary;
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.record.StandardRecord;
+import com.hurence.logisland.serializer.AvroSerializer;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
@@ -42,7 +47,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.commons.cli.*;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -52,6 +56,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 
 
 public class DataGenerator {
@@ -82,19 +90,81 @@ public class DataGenerator {
      * Generate random based on the avro schema
      * The schema must be of a record type to work
      *
+     *
      * @return returns the randomly generated record
      */
-    public GenericRecord generateRandomRecord() throws UnknownTypeException {
+    public Record generateRandomRecord(String recordType) throws UnknownTypeException {
 
-        if (schema.getType() != Schema.Type.RECORD) {
-            logger.error("The schema first level must be record.");
-            return null;
-        }
+        GenericRecord eventRecord = generateGenericAvroRecord();
+        Record record = new StandardRecord(recordType);
 
-        GenericRecord record = new GenericData.Record(schema);
-        for (Field field : schema.getFields()) {
-            SchemaFiller schemaFill = SchemaFiller.createRandomField(field);
-            schemaFill.writeToRecord(record);
+
+        for (final Schema.Field schemaField : schema.getFields()) {
+
+            final String fieldName = schemaField.name();
+            final Object fieldValue = eventRecord.get(fieldName);
+            final FieldType fieldType;
+            {
+                /**
+                 * currently all avro type are : RECORD,ENUM,ARRAY,MAP,UNION,FIXED,STRING,BYTES,INT,LONG,FLOAT,DOUBLE,BOOLEAN,NULL;
+                 * all LogIsland type are : RECORD,ENUM,ARRAY,MAP,STRING,BYTES,INT,LONG,FLOAT,DOUBLE,BOOLEAN,NULL;
+                 *
+                 * So we lack of types: UNION, FIXED
+                 */
+                Schema.Type avroType = schemaField.schema().getType();
+                switch (avroType) {
+                    case UNION:
+                        List<Schema> schemas = schemaField.schema().getTypes();
+                        List<Schema.Type> types = new LinkedList<>();
+                        for (Schema schemaF2 : schemas) {
+                            types.add(schemaF2.getType());
+                        }
+
+                        if (types.size() > 2 || !types.contains(Schema.Type.NULL)) {
+                            throw new UnsupportedOperationException(
+                                    "avro schema with types UNION with another format than '['null', 'atype']' is not yet supported"
+                            );
+                        }
+                        Schema.Type determineType = null;
+                        for (Schema.Type type : types) {
+                            switch (type) {
+                                case NULL:
+                                    break;
+                                default:
+                                    determineType = type;
+                                    break;
+                            }
+                        }
+                        if (determineType == null) {
+                            throw new UnsupportedOperationException("UNION of null type makes no sense");
+                        }
+                        fieldType = FieldType.valueOf(determineType.getName().toUpperCase());
+                        break;
+                    case FIXED:
+                        //TODO verify this is a correct behaviour
+                        fieldType = FieldType.STRING;
+                        break;
+                    default:
+                        fieldType = FieldType.valueOf(avroType.getName().toUpperCase());
+                        break;
+                }
+            }
+
+            if (Objects.equals(fieldName, FieldDictionary.RECORD_ID)) {
+                record.setId(fieldValue.toString());
+            } else if (!Objects.equals(fieldName, FieldDictionary.RECORD_TYPE)) {
+                if (fieldValue instanceof org.apache.avro.util.Utf8) {
+                    record.setStringField(fieldName, fieldValue.toString());
+                } else if (fieldValue instanceof GenericData.Array) {
+                    GenericData.Array avroArray = (GenericData.Array) fieldValue;
+                    List<Object> list = new ArrayList<>();
+                    record.setField(fieldName, FieldType.ARRAY, list);
+                    AvroSerializer.copyArray(avroArray, list);
+                } else {
+                    record.setField(fieldName, fieldType, fieldValue);
+                }
+
+            }
         }
         return record;
     }
@@ -131,6 +201,21 @@ public class DataGenerator {
         formatter.printHelp("Generate a record with random data given an Avro schema", opts);
     }
 
+    private GenericRecord generateGenericAvroRecord() throws UnknownTypeException {
+        if (schema.getType() != Schema.Type.RECORD) {
+            logger.error("The schema first level must be record.");
+            return null;
+        }
+
+        GenericRecord eventRecord = new GenericData.Record(schema);
+        for (Field field : schema.getFields()) {
+            SchemaFiller schemaFill = SchemaFiller.createRandomField(field);
+            schemaFill.writeToRecord(eventRecord);
+        }
+        return eventRecord;
+
+    }
+
     public static void main(String[] args) throws IOException, UnknownTypeException {
 
         // load and verify the options
@@ -158,7 +243,7 @@ public class DataGenerator {
         // Generate the record
         File schemaFile = new File(fileLoc);
         DataGenerator dataGenerator = new DataGenerator(schemaFile);
-        GenericRecord record = dataGenerator.generateRandomRecord();
+        GenericRecord record = dataGenerator.generateGenericAvroRecord();
         if (cmd.hasOption(PRINT_AVRO_JSON_OPTNAME)) {
             String outname = cmd.getOptionValue(PRINT_AVRO_JSON_OPTNAME);
             OutputStream outs = System.out;

--- a/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/record/RecordSchemaUtil.java
+++ b/logisland-core/logisland-framework/logisland-utils/src/main/java/com/hurence/logisland/util/record/RecordSchemaUtil.java
@@ -113,6 +113,10 @@ public class RecordSchemaUtil {
         return builder.toString();
     }
 
+    public static Schema compileSchema(String schema) {
+        return new Schema.Parser().parse(schema);
+    }
+
     public static synchronized Record convertToValidRecord(final Record inputRecord, final Schema schema) {
         final Record outputRecord = new StandardRecord(inputRecord.getType());
 

--- a/logisland-core/logisland-framework/logisland-utils/src/test/java/com/hurence/logisland/serializer/ExtendedJsonSerializerTest.java
+++ b/logisland-core/logisland-framework/logisland-utils/src/test/java/com/hurence/logisland/serializer/ExtendedJsonSerializerTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Hurence (support@hurence.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,10 +24,11 @@ import com.hurence.logisland.record.Record;
 import com.hurence.logisland.record.StandardRecord;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Date;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -36,9 +37,6 @@ import static org.junit.Assert.assertTrue;
  * @author tom
  */
 public class ExtendedJsonSerializerTest {
-
-
-
 
 
     @Test
@@ -124,8 +122,6 @@ public class ExtendedJsonSerializerTest {
                 "}";
 
 
-
-
         final ExtendedJsonSerializer serializer = new ExtendedJsonSerializer(schema);
         ByteArrayInputStream bais = new ByteArrayInputStream(recordStr.getBytes());
         Record deserializedRecord = serializer.deserialize(bais);
@@ -137,8 +133,6 @@ public class ExtendedJsonSerializerTest {
 
         System.out.println(new String(baos.toByteArray()));
     }
-
-
 
 
     @Test
@@ -162,7 +156,7 @@ public class ExtendedJsonSerializerTest {
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         Record deserializedRecord = serializer.deserialize(bais);
 
-       // assertEquals(record.getAllFieldsSorted(), deserializedRecord.getAllFieldsSorted());
+        // assertEquals(record.getAllFieldsSorted(), deserializedRecord.getAllFieldsSorted());
 
     }
 

--- a/logisland-core/logisland-framework/logisland-utils/src/test/java/com/hurence/logisland/serializer/ExtendedJsonSerializerTest.java
+++ b/logisland-core/logisland-framework/logisland-utils/src/test/java/com/hurence/logisland/serializer/ExtendedJsonSerializerTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.io.*;
 import java.util.Date;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -212,4 +213,57 @@ public class ExtendedJsonSerializerTest {
         assertTrue(deserializedRecord.getTime().getTime() == 1493286300033L);
     }
 
+    @Test
+    public void testFormatDate() throws Exception {
+        final String schema = "{\n" +
+                "  \"version\": 1,\n" +
+                "  \"type\": \"record\",\n" +
+                "  \"namespace\": \"test\",\n" +
+                "  \"name\": \"test\",\n" +
+                "  \"fields\": [  \n" +
+                "    {\n" +
+                "      \"name\": \"myDateAsString\",\n" +
+                "      \"type\":  {\n" +
+                "        \"type\": \"int\",\n" +
+                "        \"logicalType\": \"date\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"name\": \"myTimestampAsString\",\n" +
+                "      \"type\":  {\n" +
+                "        \"type\": \"long\",\n" +
+                "        \"logicalType\": \"timestamp-millis\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"name\": \"myTimestampAsEpoch\",\n" +
+                "      \"type\":  {\n" +
+                "        \"type\": \"long\",\n" +
+                "        \"logicalType\": \"timestamp-millis\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"name\": \"unformattedDate\",\n" +
+                "      \"type\":  \"long\"\n" +
+                "    }\n" +
+                " ]\n" +
+                "}\n";
+
+        final String json = "{\n" +
+                "  \"myTimestampAsEpoch\": 1541494638000,\n" +
+                "  \"myTimestampAsString\" : \"2018-11-06T08:57:18.000Z\",\n" +
+                "  \"myDateAsString\": \"20181106\",\n" +
+                "  \"unformattedDate\" : 1541494638000\n" +
+                "}";
+
+
+        final ExtendedJsonSerializer serializer = new ExtendedJsonSerializer(schema);
+        final Record record = serializer.deserialize(new ByteArrayInputStream(json.getBytes("UTF8")));
+        System.out.println(record);
+        assertEquals(FieldType.DATETIME, record.getField("myTimestampAsEpoch").getType());
+        assertEquals(FieldType.DATETIME, record.getField("myTimestampAsString").getType());
+        assertEquals(FieldType.DATETIME, record.getField("myDateAsString").getType());
+        assertEquals(FieldType.LONG, record.getField("unformattedDate").getType());
+
+    }
 }

--- a/logisland-core/pom.xml
+++ b/logisland-core/pom.xml
@@ -103,11 +103,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>1.7.7</version>
-            </dependency>
-            <dependency>
                 <groupId>com.esotericsoftware.kryo</groupId>
                 <artifactId>kryo</artifactId>
                 <version>2.21</version>

--- a/logisland-documentation/components.rst
+++ b/logisland-documentation/components.rst
@@ -1139,6 +1139,38 @@ In the list below, the names of required properties appear in **bold**. Any othe
 
 ----------
 
+.. _com.hurence.logisland.processor.ExpandMapFields: 
+
+ExpandMapFields
+---------------
+Expands the content of a MAP field to the root.
+
+Module
+______
+com.hurence.logisland:logisland-processor-common:1.0.0-RC1
+
+Class
+_____
+com.hurence.logisland.processor.ExpandMapFields
+
+Tags
+____
+record, fields, Expand, Map
+
+Properties
+__________
+In the list below, the names of required properties appear in **bold**. Any other properties (not in bold) are considered optional. The table also indicates any default values
+.
+
+.. csv-table:: allowable-values
+   :header: "Name","Description","Allowable Values","Default Value","Sensitive","EL"
+   :widths: 20,60,30,20,10,10
+
+   "**fields.to.expand**", "Comma separated list of fields of type map that will be expanded to the root", "", "null", "", ""
+   "conflict.resolution.policy", "What to do when a field with the same name already exists ?", "overwrite existing field (if field already exist), keep only old field value (keep only old field)", "keep_only_old_field", "", ""
+
+----------
+
 .. _com.hurence.logisland.processor.hbase.FetchHBaseRow: 
 
 FetchHBaseRow
@@ -1595,9 +1627,10 @@ In the list below, the names of required properties appear in **bold**. Any othe
    "**mongo.collection.name**", "The name of the collection to use", "", "null", "", "**true**"
    "batch.size", "The preferred number of Records to setField to the database in a single transaction", "", "1000", "", ""
    "bulk.size", "bulk size in MB", "", "5", "", ""
-   "bulk.mode", "Bulk mode (insert or upsert)", "Insert (Insert records whose key must be unique), Insert or Update (Insert records if not already existing or update the record if already existing)", "insert", "", ""
+   "mongo.bulk.mode", "Bulk mode (insert or upsert)", "Insert (Insert records whose key must be unique), Insert or Update (Insert records if not already existing or update the record if already existing)", "insert", "", ""
    "flush.interval", "flush interval in ms", "", "500", "", ""
    "**mongo.write.concern**", "The write concern to use", "ACKNOWLEDGED, UNACKNOWLEDGED, FSYNCED, JOURNALED, REPLICA_ACKNOWLEDGED, MAJORITY", "ACKNOWLEDGED", "", ""
+   "mongo.bulk.upsert.condition", "A custom condition for the bulk upsert (Filter for the bulkwrite). If not specified the standard condition is to match same id ('_id': data._id)", "", "${'{ "_id" :"' + record_id + '"}'}", "", "**true**"
 
 ----------
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,6 @@
                 <scope>provided</scope>
             </dependency>
 
-
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>


### PR DESCRIPTION
Several improvements here:

* MongoDB: Allow to use custom condition for upserts
* MongoDB: Fix potentials data loss (also reported by https://github.com/Hurence/logisland/issues/409)
* Framework: introduce datatime field type
* Framework: extend the EL to use accessors (e.g. maps and nested types)
* Serializers: Use Avro 1.8.2
* Serializers: Allow ExtendedJsonSerializer to interpret date/time/datetime from an avro schema
* Processors: ExpandMapField processor to flatten map field to the record root
* HDFS: Allow hdfs burner to gather raw data and interpret as a json by joining dataframe with record type and datetime in order to have expected information needed for partitioning partitioning