### PR TITLE
Feature/logisland 479

### DIFF
--- a/logisland-assembly/pom.xml
+++ b/logisland-assembly/pom.xml
@@ -490,6 +490,11 @@
                 </dependency>
                 <dependency>
                     <groupId>com.hurence.logisland</groupId>
+                    <artifactId>logisland-service-elasticsearch_7_x-client</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.hurence.logisland</groupId>
                     <artifactId>logisland-service-solr_5_5_5-client</artifactId>
                     <version>${project.version}</version>
                 </dependency>

--- a/logisland-assembly/src/assembly/dependencies.xml
+++ b/logisland-assembly/src/assembly/dependencies.xml
@@ -26,14 +26,18 @@
     <baseDirectory>logisland-${project.version}</baseDirectory>
 
     <dependencySets>
-        <!-- Write out all dependency artifacts to lib directory -->
+        <!-- Write out all dependency artifacts to lib directory.
+             This includes plugins (services...), that is plugin
+             fatjars and not their dependencies, but also includes
+             dependencies of the assembly pom -->
         <dependencySet>
             <scope>runtime</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <outputDirectory>lib</outputDirectory>
             <directoryMode>0770</directoryMode>
             <fileMode>0660</fileMode>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <useTransitiveFiltering>false</useTransitiveFiltering>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
             <excludes>
                 <exclude>logisland-resources</exclude>
                 <exclude>logisland-documentation</exclude>
@@ -42,6 +46,30 @@
                 <exclude>logisland-engine-spark_1_6</exclude>
                 <exclude>logisland-engine-vanilla</exclude>
             </excludes>
+        </dependencySet>
+
+        <dependencySet>
+           <!-- This includes shared bits needed by all logisland components and
+                their dependencies as well (additional jars) -->
+           <scope>runtime</scope>
+           <useProjectArtifact>false</useProjectArtifact>
+           <outputDirectory>lib</outputDirectory>
+           <directoryMode>0770</directoryMode>
+           <fileMode>0660</fileMode>
+           <useTransitiveFiltering>true</useTransitiveFiltering>
+           <useTransitiveDependencies>true</useTransitiveDependencies>
+           <includes>
+               <include>logisland-api</include>
+               <include>logisland-utils</include>
+               <include>logisland-bootstrap</include>
+               <include>logisland-hadoop-utils</include>
+               <include>logisland-plugin-support</include>
+               <include>logisland-scripting-base</include>
+               <include>logisland-scripting-mvel</include>
+               <include>scala-logging-*</include>
+               <include>log4j-to-slf4j</include>
+               <include>slf4j-api</include>
+           </includes>
         </dependencySet>
 
         <dependencySet>

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/ESRule.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/ESRule.java
@@ -1,5 +1,5 @@
  /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2019 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_6_6_2_ClientServiceIT.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_6_6_2_ClientServiceIT.java
@@ -1,5 +1,5 @@
  /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2019 Hurence (support@hurence.com)
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/TestProcessor.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/TestProcessor.java
@@ -1,5 +1,5 @@
  /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2019 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/main/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverter.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/main/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2019 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/main/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_6_6_2_ClientService.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/main/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_6_6_2_ClientService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2019 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/main/java/com/hurence/logisland/service/elasticsearch/GeoPoint.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/main/java/com/hurence/logisland/service/elasticsearch/GeoPoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2019 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/test/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverterTest.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_6_6_2-client/src/test/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Hurence (support@hurence.com)
+ * Copyright (C) 2019 Hurence (support@hurence.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/pom.xml
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.hurence.logisland</groupId>
+        <artifactId>logisland-service-elasticsearch</artifactId>
+        <version>1.1.2</version>
+    </parent>
+
+    <artifactId>logisland-service-elasticsearch_7_x-client</artifactId>
+    <packaging>jar</packaging>
+    <name>Elasticsearch 7.x Service Plugin</name>
+
+    <properties>
+        <!-- Versions -->
+        <elasticsearch.version>7.1.1</elasticsearch.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${org.slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hurence.logisland</groupId>
+            <artifactId>logisland-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hurence.logisland</groupId>
+            <artifactId>logisland-service-elasticsearch-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.10.7</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>1.10.7</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hurence.logisland</groupId>
+            <artifactId>logisland-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.11.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.11.1</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.hurence.logisland</groupId>
+                <artifactId>logisland-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/pom.xml
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/pom.xml
@@ -88,6 +88,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Needed for unit test: logisland-utils depends on jackson core 2.4.4
+          (com.fasterxml.jackson.core:jackson-core:jar:2.4.4) which is not sufficient for
+          the unit tests. Howevern we need logisland-utils for unit tests so adding
+          dependency on higher version of jackson core so that the TokenFilter class is found
+          in classpath -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.9</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/ESRule.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/ESRule.java
@@ -1,0 +1,71 @@
+ /**
+ * Copyright (C) 2019 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hurence.logisland.service.elasticsearch;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestClient;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+ /**
+ * A JUnit rule which starts an embedded elastic-search docker container.
+ * <p>
+ * Tests which use this rule will run relatively slowly, and should only be used when more conventional unit tests are
+ * not sufficient - eg when testing DAO-specific code.
+ * </p>
+ */
+public class ESRule implements TestRule {
+
+    /**
+     * The internal-transport client that talks to the local node.
+     */
+    private RestHighLevelClient client;
+
+    /**
+     * Return a closure which starts an embedded ES docker container, executes the unit-test, then shuts down the
+     * ES instance.
+     */
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.7.1");
+                container.start();
+                client = new RestHighLevelClient(RestClient.builder(HttpHost.create(container.getHttpHostAddress())));
+
+                try {
+                    base.evaluate(); // execute the unit test
+                } finally {
+                    client.close();
+                    container.stop();
+                }
+            }
+        };
+    }
+
+    /**
+     * Return the object through which operations can be performed on the ES cluster.
+     */
+    public RestHighLevelClient getClient() {
+        return client;
+    }
+
+}

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/ESRule.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/ESRule.java
@@ -47,7 +47,7 @@ public class ESRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.7.1");
+                ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.1.1");
                 container.start();
                 client = new RestHighLevelClient(RestClient.builder(HttpHost.create(container.getHttpHostAddress())));
 

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_7_x_ClientServiceIT.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_7_x_ClientServiceIT.java
@@ -1,0 +1,566 @@
+ /**
+ * Copyright (C) 2019 Hurence (support@hurence.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hurence.logisland.service.elasticsearch;
+
+import com.hurence.logisland.classloading.PluginProxy;
+import com.hurence.logisland.component.InitializationException;
+import com.hurence.logisland.component.PropertyDescriptor;
+import com.hurence.logisland.controller.ControllerServiceInitializationContext;
+import com.hurence.logisland.processor.ProcessException;
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.record.StandardRecord;
+import com.hurence.logisland.service.datastore.InvalidMultiGetQueryRecordException;
+import com.hurence.logisland.service.datastore.MultiGetQueryRecord;
+import com.hurence.logisland.service.datastore.MultiGetResponseRecord;
+import com.hurence.logisland.util.runner.TestRunner;
+import com.hurence.logisland.util.runner.TestRunners;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.BiConsumer;
+
+public class Elasticsearch_7_x_ClientServiceIT {
+
+    private static final String MAPPING1 = "{'properties':{'name':{'type': 'text'},'val':{'type':'integer'}}}";
+    private static final String MAPPING2 = "{'properties':{'name':{'type': 'text'},'val':{'type': 'text'}}}";
+    private static final String MAPPING3 =
+            "{'dynamic':'strict','properties':{'name':{'type': 'text'},'xyz':{'type': 'text'}}}";
+
+    private static Logger logger = LoggerFactory.getLogger(Elasticsearch_7_x_ClientServiceIT.class);
+
+    @Rule
+    public final ESRule esRule = new ESRule();
+
+
+    private class MockElasticsearchClientService extends Elasticsearch_7_x_ClientService {
+
+        @Override
+        protected void createElasticsearchClient(ControllerServiceInitializationContext context) throws ProcessException {
+            if (esClient != null) {
+                return;
+            }
+            esClient = esRule.getClient();
+        }
+
+        @Override
+        protected void createBulkProcessor(ControllerServiceInitializationContext context) {
+
+            if (bulkProcessor != null) {
+                return;
+            }
+
+            // create the bulk processor
+
+            BulkProcessor.Listener listener =
+                    new BulkProcessor.Listener() {
+                        @Override
+                        public void beforeBulk(long l, BulkRequest bulkRequest) {
+                            getLogger().debug("Going to execute bulk [id:{}] composed of {} actions", new Object[]{l, bulkRequest.numberOfActions()});
+                        }
+
+                        @Override
+                        public void afterBulk(long l, BulkRequest bulkRequest, BulkResponse bulkResponse) {
+                            getLogger().debug("Executed bulk [id:{}] composed of {} actions", new Object[]{l, bulkRequest.numberOfActions()});
+                            if (bulkResponse.hasFailures()) {
+                                getLogger().warn("There was failures while executing bulk [id:{}]," +
+                                                " done bulk request in {} ms with failure = {}",
+                                        new Object[]{l, bulkResponse.getTook().getMillis(), bulkResponse.buildFailureMessage()});
+                                for (BulkItemResponse item : bulkResponse.getItems()) {
+                                    if (item.isFailed()) {
+                                        errors.put(item.getId(), item.getFailureMessage());
+                                    }
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void afterBulk(long l, BulkRequest bulkRequest, Throwable throwable) {
+                            getLogger().error("something went wrong while bulk loading events to es : {}", new Object[]{throwable.getMessage()});
+                        }
+
+                    };
+
+            BiConsumer<BulkRequest, ActionListener<BulkResponse>> bulkConsumer =
+                    (request, bulkListener) -> esClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
+            bulkProcessor = BulkProcessor.builder(bulkConsumer, listener)
+                    .setBulkActions(1000)
+                    .setBulkSize(new ByteSizeValue(10, ByteSizeUnit.MB))
+                    .setFlushInterval(TimeValue.timeValueSeconds(1))
+                    .setConcurrentRequests(2)
+                    //.setBackoffPolicy(getBackOffPolicy(context))
+                    .build();
+
+        }
+
+        @Override
+        public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+
+            List<PropertyDescriptor> props = new ArrayList<>();
+
+            return Collections.unmodifiableList(props);
+        }
+
+    }
+
+    private ElasticsearchClientService configureElasticsearchClientService(final TestRunner runner) throws InitializationException {
+        final MockElasticsearchClientService elasticsearchClientService = new MockElasticsearchClientService();
+
+        runner.addControllerService("elasticsearchClient", elasticsearchClientService);
+
+        runner.enableControllerService(elasticsearchClientService);
+        runner.setProperty(TestProcessor.ELASTICSEARCH_CLIENT_SERVICE, "elasticsearchClient");
+        runner.assertValid(elasticsearchClientService);
+
+        // TODO : is this necessary ?
+        final ElasticsearchClientService service = PluginProxy.unwrap(runner.getProcessContext().getPropertyValue(TestProcessor.ELASTICSEARCH_CLIENT_SERVICE).asControllerService());
+        return service;
+    }
+
+    @Test
+    public void testBasics() throws Exception {
+
+        Map<String, Object> document1 = new HashMap<>();
+        document1.put("name", "fred");
+        document1.put("val", 33);
+
+        boolean result;
+
+        final TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
+
+        final ElasticsearchClientService elasticsearchClientService = configureElasticsearchClientService(runner);
+
+
+        // Verify the index does not exist
+        Assert.assertEquals(false, elasticsearchClientService.existsCollection("foo"));
+
+        // Define the index
+        elasticsearchClientService.createCollection("foo", 2, 1);
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection("foo"));
+
+        // Define another index
+        elasticsearchClientService.createCollection("bar", 2, 1);
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection("foo"));
+
+        // Add a mapping to foo
+        result = elasticsearchClientService.putMapping("foo", "type1", MAPPING1.replace('\'', '"'));
+        Assert.assertEquals(true, result);
+
+        // Add the same mapping again
+        result = elasticsearchClientService.putMapping("foo", "type1", MAPPING1.replace('\'', '"'));
+        Assert.assertEquals(true, result);
+
+        // Update a mapping with an incompatible mapping -- should fail
+        // result = elasticsearchClientService.putMapping("foo", "type2", MAPPING2.replace('\'', '"'));
+        // Assert.assertEquals(false, result);
+
+        // create alias
+        elasticsearchClientService.createAlias("foo", "aliasFoo");
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection("aliasFoo"));
+
+        // Insert a record into foo and count foo
+        Assert.assertEquals(0, elasticsearchClientService.countCollection("foo"));
+        elasticsearchClientService.saveSync("foo", "type1", document1);
+        Assert.assertEquals(1, elasticsearchClientService.countCollection("foo"));
+
+        // copy index foo to bar - should work
+        Assert.assertEquals(0, elasticsearchClientService.countCollection("bar"));
+        elasticsearchClientService.copyCollection(TimeValue.timeValueMinutes(2).toString(), "foo", "bar");
+        elasticsearchClientService.bulkFlush();
+        Thread.sleep(2000);
+        elasticsearchClientService.refreshCollection("bar");
+        Assert.assertEquals(1, elasticsearchClientService.countCollection("bar"));
+
+        // Define incompatible mappings for the same doctype in two different indexes, then try to copy - should fail
+        // as a document registered with doctype=type1 in index foo cannot be written as doctype=type1 in index baz.
+        //
+        // Note: MAPPING2 cannot be added to index foo or bar at all, even under a different doctype, as ES (lucene)
+        // does not allow two types for the same field-name in different mappings of the same index. However if
+        // MAPPING2 is added to index baz, then the copyCollection succeeds - because by default ES automatically converts
+        // integers into strings when necessary. Interestingly, this means MAPPING1 and MAPPING2 are not compatible
+        // at the "put mapping" level, but are compatible at the "reindex" level..
+        //
+        // The document (doc1) of type "type1" already in index "foo" cannot be inserted into index "baz" as type1
+        // because that means applying its source to MAPPING3 - but MAPPING3 is strict and does not define property
+        // "val", so the insert fails.
+        elasticsearchClientService.createCollection("baz",2, 1);
+        elasticsearchClientService.putMapping("baz", "type1", MAPPING3.replace('\'', '"'));
+
+      /*  try {
+            elasticsearchClientService.copyCollection(TimeValue.timeValueMinutes(2), "foo", "baz");
+            Assert.fail("Exception not thrown when expected");
+        } catch(IOException e) {
+            Assert.assertTrue(e.getMessage().contains("Reindex failed"));
+        }*/
+        elasticsearchClientService.refreshCollection("baz");
+        Assert.assertEquals(0, elasticsearchClientService.countCollection("baz"));
+
+        // Drop index foo
+        elasticsearchClientService.dropCollection("foo");
+        Assert.assertEquals(false, elasticsearchClientService.existsCollection("foo"));
+        Assert.assertEquals(false, elasticsearchClientService.existsCollection("aliasFoo")); // alias for foo disappears too
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection("bar"));
+    }
+
+    @Test
+    public void testBulkPut() throws InitializationException, IOException, InterruptedException {
+        final String index = "foo";
+        final String type = "type1";
+        final String docId = "id1";
+        final String nameKey = "name";
+        final String nameValue = "fred";
+        final String ageKey = "age";
+        final int ageValue = 33;
+
+        Map<String, Object> document1 = new HashMap<>();
+        document1.put(nameKey, nameValue);
+        document1.put(ageKey, ageValue);
+
+        final TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
+
+        // create the controller service and link it to the test processor :
+        final ElasticsearchClientService elasticsearchClientService = configureElasticsearchClientService(runner);
+
+        // Verify the index does not exist
+        Assert.assertEquals(false, elasticsearchClientService.existsCollection(index));
+
+        // Create the index
+        elasticsearchClientService.createCollection(index,2, 1);
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection(index));
+
+        // Put a document in the bulk processor :
+        elasticsearchClientService.bulkPut(index, type, document1, Optional.of(docId));
+        // Flush the bulk processor :
+        elasticsearchClientService.bulkFlush();
+        Thread.sleep(2000);
+        try {
+            // Refresh the index :
+            elasticsearchClientService.refreshCollection(index);
+        } catch (Exception e) {
+            logger.error("Error while refreshing the index : " + e.toString());
+        }
+
+        long documentsNumber = 0;
+
+        try {
+            documentsNumber = elasticsearchClientService.countCollection(index);
+        } catch (Exception e) {
+            logger.error("Error while counting the number of documents in the index : " + e.toString());
+        }
+
+        Assert.assertEquals(1, documentsNumber);
+
+        try {
+            elasticsearchClientService.saveSync(index, type, document1);
+        } catch (Exception e) {
+            logger.error("Error while saving the document in the index : " + e.toString());
+        }
+
+        try {
+            documentsNumber = elasticsearchClientService.countCollection(index);
+        } catch (Exception e) {
+            logger.error("Error while counting the number of documents in the index : " + e.toString());
+        }
+
+        Assert.assertEquals(2, documentsNumber);
+
+        long numberOfHits = elasticsearchClientService.searchNumberOfHits(index, type, nameKey, nameValue);
+
+        Assert.assertEquals(2, numberOfHits);
+
+    }
+
+
+    @Test
+    public void testBulkPutGeopoint() throws InitializationException, IOException, InterruptedException {
+        final String index = "future_factory";
+        final String type = "factory";
+        final String docId = "modane_factory";
+        Record record = new StandardRecord("factory")
+                .setId(docId)
+                .setStringField("address", "rue du Frejus")
+                .setField("latitude", FieldType.FLOAT, 45.4f)
+                .setField("longitude", FieldType.FLOAT, 45.4f);
+
+        final TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
+
+        // create the controller service and link it to the test processor :
+        final ElasticsearchClientService elasticsearchClientService = configureElasticsearchClientService(runner);
+
+        // Verify the index does not exist
+        Assert.assertEquals(false, elasticsearchClientService.existsCollection(index));
+
+        // Create the index
+        elasticsearchClientService.createCollection(index, 2, 1);
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection(index));
+
+        // Put a document in the bulk processor :
+        String document1 = ElasticsearchRecordConverter.convertToString(record);
+        elasticsearchClientService.bulkPut(index, type, document1, Optional.of(docId));
+        // Flush the bulk processor :
+        elasticsearchClientService.bulkFlush();
+        Thread.sleep(2000);
+        try {
+            // Refresh the index :
+            elasticsearchClientService.refreshCollection(index);
+        } catch (Exception e) {
+            logger.error("Error while refreshing the index : " + e.toString());
+        }
+
+        long documentsNumber = 0;
+
+        try {
+            documentsNumber = elasticsearchClientService.countCollection(index);
+        } catch (Exception e) {
+            logger.error("Error while counting the number of documents in the index : " + e.toString());
+        }
+
+        Assert.assertEquals(1, documentsNumber);
+
+        List<MultiGetQueryRecord> multiGetQueryRecords = new ArrayList<>();
+        ArrayList<String> documentIds = new ArrayList<>();
+        List<MultiGetResponseRecord> multiGetResponseRecords = new ArrayList<>();
+
+
+        // Make sure a dummy query returns no result :
+        documentIds.add(docId);
+        try {
+            multiGetQueryRecords.add(new MultiGetQueryRecord(index, type, new String[]{"location", "id"}, new String[]{}, documentIds));
+        } catch (InvalidMultiGetQueryRecordException e) {
+            e.printStackTrace();
+        }
+        multiGetResponseRecords = elasticsearchClientService.multiGet(multiGetQueryRecords);
+        Assert.assertEquals(1, multiGetResponseRecords.size()); // number of documents retrieved
+
+    }
+
+
+    @Test
+    public void testMultiGet() throws InitializationException, IOException, InterruptedException, InvalidMultiGetQueryRecordException {
+        final String index1 = "index1";
+        final String index2 = "index2";
+        final String type1 = "type1";
+
+        Map<String, Object> document1 = new HashMap<>();
+        final String docId1 = "id1";
+        document1.put("field_beg_1", "field_beg_1_document1_value");
+        document1.put("field_beg_2", "field_beg_2_document1_value");
+        document1.put("field_beg_3", "field_beg_3_document1_value");
+        document1.put("field_fin_1", "field_fin_1_document1_value");
+        document1.put("field_fin_2", "field_fin_2_document1_value");
+
+        Map<String, Object> document2 = new HashMap<>();
+        final String docId2 = "id2";
+        document2.put("field_beg_1", "field_beg_1_document2_value");
+        document2.put("field_beg_2", "field_beg_2_document2_value");
+        document2.put("field_beg_3", "field_beg_3_document2_value");
+        document2.put("field_fin_1", "field_fin_1_document2_value");
+        document2.put("field_fin_2", "field_fin_2_document2_value");
+
+        Map<String, Object> document3 = new HashMap<>();
+        final String docId3 = "id3";
+        document3.put("field_beg_1", "field_beg_1_document3_value");
+        document3.put("field_beg_2", "field_beg_2_document3_value");
+        // this 3rd field is intentionally removed :
+        // document3.put("field_beg_3", "field_beg_3_document3_value");
+        document3.put("field_fin_1", "field_fin_1_document3_value");
+        document3.put("field_fin_2", "field_fin_2_document3_value");
+
+        final TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
+
+        // create the controller service and link it to the test processor :
+        final ElasticsearchClientService elasticsearchClientService = configureElasticsearchClientService(runner);
+
+        // Verify the indexes do not exist
+        Assert.assertEquals(false, elasticsearchClientService.existsCollection(index1));
+        Assert.assertEquals(false, elasticsearchClientService.existsCollection(index2));
+
+        // Create the indexes
+        elasticsearchClientService.createCollection(index1, 2, 1);
+        elasticsearchClientService.createCollection(index2, 2, 1);
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection(index1));
+        Assert.assertEquals(true, elasticsearchClientService.existsCollection(index2));
+
+        // Put documents in the bulk processor :
+        elasticsearchClientService.bulkPut(index1, type1, document1, Optional.of(docId1));
+        elasticsearchClientService.bulkPut(index1, type1, document2, Optional.of(docId2));
+        elasticsearchClientService.bulkPut(index1, type1, document3, Optional.of(docId3));
+        elasticsearchClientService.bulkPut(index2, type1, document1, Optional.of(docId1));
+        elasticsearchClientService.bulkPut(index2, type1, document2, Optional.of(docId2));
+        elasticsearchClientService.bulkPut(index2, type1, document3, Optional.of(docId3));
+        // Flush the bulk processor :
+        elasticsearchClientService.bulkFlush();
+        Thread.sleep(2000);
+        try {
+            // Refresh the indexes :
+            elasticsearchClientService.refreshCollection(index1);
+            elasticsearchClientService.refreshCollection(index2);
+        } catch (Exception e) {
+            logger.error("Error while refreshing the indexes : " + e.toString());
+        }
+
+        long countIndex1 = 0;
+        long countIndex2 = 0;
+        try {
+            countIndex1 = elasticsearchClientService.countCollection(index1);
+            countIndex2 = elasticsearchClientService.countCollection(index2);
+        } catch (Exception e) {
+            logger.error("Error while counting the number of documents in the index : " + e.toString());
+        }
+        Assert.assertEquals(3, countIndex1);
+        Assert.assertEquals(3, countIndex2);
+
+        List<MultiGetQueryRecord> multiGetQueryRecords = new ArrayList<>();
+        ArrayList<String> documentIds = new ArrayList<>();
+        ArrayList<String> documentIds_2 = new ArrayList<>();
+        List<MultiGetResponseRecord> multiGetResponseRecords;
+        String[] fieldsToInclude = {"field_b*", "field*1"};
+        String[] fieldsToExclude = {"field_*2"};
+
+        // Make sure a dummy query returns no result :
+        documentIds.add(docId1);
+        multiGetQueryRecords.add(new MultiGetQueryRecord("dummy", "", new String[]{"dummy"}, new String[]{}, documentIds));
+        multiGetResponseRecords = elasticsearchClientService.multiGet(multiGetQueryRecords);
+        Assert.assertEquals(0, multiGetResponseRecords.size()); // number of documents retrieved
+
+        multiGetQueryRecords.clear();
+        documentIds.clear();
+        multiGetResponseRecords.clear();
+
+        // Test : 1 MultiGetQueryRecord record, with 1 index, 1 type, 1 id, WITHOUT includes, WITHOUT excludes :
+        documentIds.add(docId1);
+        multiGetQueryRecords.add(new MultiGetQueryRecord(index1, type1, documentIds));
+        multiGetResponseRecords = elasticsearchClientService.multiGet(multiGetQueryRecords);
+
+        Assert.assertEquals(1, multiGetResponseRecords.size()); // number of documents retrieved
+        Assert.assertEquals(index1, multiGetResponseRecords.get(0).getCollectionName());
+        Assert.assertEquals(type1, multiGetResponseRecords.get(0).getTypeName());
+        Assert.assertEquals(docId1, multiGetResponseRecords.get(0).getDocumentId());
+        Assert.assertEquals(5, multiGetResponseRecords.get(0).getRetrievedFields().size()); // number of fields retrieved for the document
+        multiGetResponseRecords.get(0).getRetrievedFields().forEach((k, v) -> document1.get(k).equals(v.toString()));
+
+        multiGetQueryRecords.clear();
+        documentIds.clear();
+        multiGetResponseRecords.clear();
+
+        // Test : 1 MultiGetQueryRecord record, with 1 index, 0 type, 3 ids, WITH include, WITH exclude :
+        documentIds.add(docId1);
+        documentIds.add(docId2);
+        documentIds.add(docId3);
+        multiGetQueryRecords.add(new MultiGetQueryRecord(index1, null, fieldsToInclude, fieldsToExclude, documentIds));
+        multiGetResponseRecords = elasticsearchClientService.multiGet(multiGetQueryRecords);
+
+        Assert.assertEquals(3, multiGetResponseRecords.size()); // verify that 3 documents has been retrieved
+        multiGetResponseRecords.forEach(responseRecord -> Assert.assertEquals(index1, responseRecord.getCollectionName())); // verify that all retrieved are in index1
+        multiGetResponseRecords.forEach(responseRecord -> Assert.assertEquals(type1, responseRecord.getTypeName())); // verify that the type of all retrieved documents is type1
+        multiGetResponseRecords.forEach(responseRecord -> {
+            if (responseRecord.getDocumentId() == docId1) {
+                Assert.assertEquals(3, responseRecord.getRetrievedFields().size()); // for document1, verify that 3 fields has been retrieved
+                // verify that the 3 retrieved fields are the correct ones :
+                Assert.assertEquals(true, responseRecord.getRetrievedFields().containsKey("field_beg_1"));
+                Assert.assertEquals(true, responseRecord.getRetrievedFields().containsKey("field_beg_3"));
+                Assert.assertEquals(true, responseRecord.getRetrievedFields().containsKey("field_fin_1"));
+                // verify that the values of the 3 retrieved fields are the correct ones :
+                Assert.assertEquals("field_beg_1_document1_value", responseRecord.getRetrievedFields().get("field_beg_1").toString());
+                Assert.assertEquals("field_beg_3_document1_value", responseRecord.getRetrievedFields().get("field_beg_3").toString());
+                Assert.assertEquals("field_fin_1_document1_value", responseRecord.getRetrievedFields().get("field_fin_1").toString());
+            }
+            if (responseRecord.getDocumentId() == docId2)
+                Assert.assertEquals(3, responseRecord.getRetrievedFields().size()); // for document2, verify that 3 fields has been retrieved
+            if (responseRecord.getDocumentId() == docId3)
+                Assert.assertEquals(2, responseRecord.getRetrievedFields().size()); // for document3, verify that 2 fields has been retrieved
+        });
+
+        multiGetQueryRecords.clear();
+        documentIds.clear();
+        multiGetResponseRecords.clear();
+
+        // Test : 2 MultiGetQueryRecord records :
+        //    - 1st : 1 index (index1), 1 type, 2 ids, WITH include, WITH exclude    --> expecting : 2 docs retrieved (from index1), 3 fields each (except doc3 : 2 fields)
+        //    - 2nd : 1 index (index2), 0 type, 3 ids, WITH include, WITHOUT exclude --> expecting : 3 docs retrieved (from index2), 4 fields each (except doc3 : 3 fields)
+        documentIds.add(docId1);
+        documentIds.add(docId2);
+        multiGetQueryRecords.add(new MultiGetQueryRecord(index1, type1, fieldsToInclude, fieldsToExclude, documentIds));
+        documentIds_2.add(docId1);
+        documentIds_2.add(docId1);
+        documentIds_2.add(docId1);
+        multiGetQueryRecords.add(new MultiGetQueryRecord(index2, null, fieldsToInclude, null, documentIds_2));
+        multiGetResponseRecords = elasticsearchClientService.multiGet(multiGetQueryRecords);
+
+        Assert.assertEquals(5, multiGetResponseRecords.size()); // verify that 5 documents has been retrieved
+        multiGetResponseRecords.forEach(responseRecord -> {
+            if (responseRecord.getCollectionName() == index1 && !responseRecord.getDocumentId().equals(docId3))
+                Assert.assertEquals(3, responseRecord.getRetrievedFields().size()); // for documents from index1 (except doc3), verify that 3 fields has been retrieved
+            if (responseRecord.getCollectionName() == index1 && responseRecord.getDocumentId().equals(docId3))
+                Assert.assertEquals(2, responseRecord.getRetrievedFields().size()); // for document3 from index1, verify that 2 fields has been retrieved
+            if (responseRecord.getDocumentId() == index2 && !responseRecord.getDocumentId().equals(docId3))
+                Assert.assertEquals(4, responseRecord.getRetrievedFields().size()); // for documents from index2 (except doc3), verify that 4 fields has been retrieved
+            if (responseRecord.getDocumentId() == index2 && responseRecord.getDocumentId().equals(docId3))
+                Assert.assertEquals(3, responseRecord.getRetrievedFields().size()); // for document3 from index2, verify that 3 fields has been retrieved
+        });
+
+    }
+
+    @Test
+    public void testMultiGetInvalidRecords() throws InitializationException, IOException, InterruptedException, InvalidMultiGetQueryRecordException {
+
+        List<MultiGetQueryRecord> multiGetQueryRecords = new ArrayList<>();
+
+        String errorMessage = "";
+
+        // Validate null index behaviour :
+        try {
+            multiGetQueryRecords.add(new MultiGetQueryRecord(null, null, null, null, null));
+        } catch (InvalidMultiGetQueryRecordException e) {
+            errorMessage = e.getMessage();
+        }
+        Assert.assertEquals(errorMessage, "The index name cannot be null");
+
+        // Validate empty index behaviour :
+        try {
+            multiGetQueryRecords.add(new MultiGetQueryRecord("", null, null, null, null));
+        } catch (InvalidMultiGetQueryRecordException e) {
+            errorMessage = e.getMessage();
+        }
+        Assert.assertEquals(errorMessage, "The index name cannot be empty");
+
+        // Validate null documentIds behaviour :
+        try {
+            multiGetQueryRecords.add(new MultiGetQueryRecord("dummy", null, null, null, null));
+        } catch (InvalidMultiGetQueryRecordException e) {
+            errorMessage = e.getMessage();
+        }
+        Assert.assertEquals(errorMessage, "The list of document ids cannot be null");
+
+        // Make sure no invalid MultiGetQueryRecord has been added to multiGetQueryRecords list :
+        Assert.assertEquals(0, multiGetQueryRecords.size());
+    }
+}

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/TestProcessor.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/integration-test/java/com/hurence/logisland/service/elasticsearch/TestProcessor.java
@@ -1,0 +1,53 @@
+ /**
+ * Copyright (C) 2019 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hurence.logisland.service.elasticsearch;
+
+import com.hurence.logisland.component.PropertyDescriptor;
+import com.hurence.logisland.processor.AbstractProcessor;
+import com.hurence.logisland.processor.ProcessContext;
+import com.hurence.logisland.record.Record;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+
+public class TestProcessor extends AbstractProcessor {
+
+    public static final PropertyDescriptor ELASTICSEARCH_CLIENT_SERVICE = new PropertyDescriptor.Builder()
+            .name("elasticsearch.client.service")
+            .description("The instance of the Controller Service to use for accessing Elasticsearch.")
+            .required(true)
+            .identifiesControllerService(ElasticsearchClientService.class)
+            .build();
+
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        List<PropertyDescriptor> propDescs = new ArrayList<>();
+        propDescs.add(ELASTICSEARCH_CLIENT_SERVICE);
+        return propDescs;
+    }
+
+    @Override
+    public Collection<Record> process(ProcessContext context, Collection<Record> records) {
+        return Collections.emptyList();
+    }
+
+
+}

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverter.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2019 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hurence.logisland.service.elasticsearch;
+
+import com.hurence.logisland.record.FieldDictionary;
+import com.hurence.logisland.record.Record;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+class ElasticsearchRecordConverter {
+
+    private static Logger logger = LoggerFactory.getLogger(ElasticsearchRecordConverter.class);
+
+    /**
+     * Converts an Event into an Elasticsearch document
+     * to be indexed later
+     *e
+     * @param record to convert
+     * @return the json converted record
+     */
+    static String convertToString(Record record) {
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            XContentBuilder document = jsonBuilder().startObject();
+            final float[] geolocation = new float[2];
+
+            // convert event_time as ISO for ES
+            if (record.hasField(FieldDictionary.RECORD_TIME)) {
+                try {
+                    DateTimeFormatter dateParser = ISODateTimeFormat.dateTimeNoMillis();
+                    document.field("@timestamp", dateParser.print(record.getField(FieldDictionary.RECORD_TIME).asLong()));
+                } catch (Exception ex) {
+                    logger.error("unable to parse record_time iso date for {}", record);
+                }
+            }
+
+            // add all other records
+            record.getAllFieldsSorted().forEach(field -> {
+                try {
+                    // cleanup invalid es fields characters like '.'
+                    String fieldName = field.getName().replaceAll("\\.", "_");
+
+
+                    switch (field.getType()) {
+
+                        case STRING:
+                            document.field(fieldName, field.asString());
+                            break;
+                        case INT:
+                            document.field(fieldName, field.asInteger().intValue());
+                            break;
+                        case LONG:
+                            document.field(fieldName, field.asLong().longValue());
+                            break;
+                        case FLOAT:
+                            document.field(fieldName, field.asFloat().floatValue());
+                            if( fieldName.equals("lat") || fieldName.equals("latitude"))
+                                geolocation[0] = field.asFloat();
+                            if( fieldName.equals("long") || fieldName.equals("longitude"))
+                                geolocation[1] = field.asFloat();
+
+                            break;
+                        case DOUBLE:
+                            document.field(fieldName, field.asDouble().doubleValue());
+                            if( fieldName.equals("lat") || fieldName.equals("latitude"))
+                                geolocation[0] = field.asFloat();
+                            if( fieldName.equals("long") || fieldName.equals("longitude"))
+                                geolocation[1] = field.asFloat();
+
+                            break;
+                        case BOOLEAN:
+                            document.field(fieldName, field.asBoolean().booleanValue());
+                            break;
+                        default:
+                            document.field(fieldName, field.getRawValue());
+                            break;
+                    }
+
+                } catch (Throwable ex) {
+                    logger.error("unable to process a field in record : {}, {}", record, ex.toString());
+                }
+            });
+
+
+            if((geolocation[0] != 0) && (geolocation[1] != 0)){
+                GeoPoint point = new GeoPoint(geolocation[0], geolocation[1]);
+                document.latlon("location", geolocation[0], geolocation[1]);
+            }
+
+
+            String result = Strings.toString(document.endObject());
+            document.flush();
+            return result;
+        } catch (Throwable ex) {
+            logger.error("unable to convert record : {}, {}", record, ex.toString());
+        }
+        return null;
+    }
+
+}

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_7_x_ClientService.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/java/com/hurence/logisland/service/elasticsearch/Elasticsearch_7_x_ClientService.java
@@ -1,0 +1,624 @@
+/**
+ * Copyright (C) 2019 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hurence.logisland.service.elasticsearch;
+
+import com.hurence.logisland.annotation.documentation.CapabilityDescription;
+import com.hurence.logisland.annotation.documentation.Tags;
+import com.hurence.logisland.annotation.lifecycle.OnDisabled;
+import com.hurence.logisland.annotation.lifecycle.OnEnabled;
+import com.hurence.logisland.component.InitializationException;
+import com.hurence.logisland.component.PropertyDescriptor;
+import com.hurence.logisland.controller.AbstractControllerService;
+import com.hurence.logisland.controller.ControllerServiceInitializationContext;
+import com.hurence.logisland.processor.ProcessException;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.service.datastore.DatastoreClientServiceException;
+import com.hurence.logisland.service.datastore.MultiGetQueryRecord;
+import com.hurence.logisland.service.datastore.MultiGetResponseRecord;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.bulk.*;
+import org.elasticsearch.action.get.*;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.*;
+import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.core.CountResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+@Tags({ "elasticsearch", "client"})
+@CapabilityDescription("Implementation of ElasticsearchClientService for Elasticsearch 7.x.")
+public class Elasticsearch_7_x_ClientService extends AbstractControllerService implements ElasticsearchClientService {
+
+
+    protected volatile RestHighLevelClient esClient;
+    private volatile HttpHost[] esHosts;
+    private volatile String authToken;
+    protected volatile BulkProcessor bulkProcessor;
+    protected volatile Map<String/*id*/, String/*errors*/> errors = new HashMap<>();
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+
+        List<PropertyDescriptor> props = new ArrayList<>();
+        props.add(BULK_BACK_OFF_POLICY);
+        props.add(BULK_THROTTLING_DELAY);
+        props.add(BULK_RETRY_NUMBER);
+        props.add(BATCH_SIZE);
+        props.add(BULK_SIZE);
+        props.add(FLUSH_INTERVAL);
+        props.add(CONCURRENT_REQUESTS);
+        props.add(PING_TIMEOUT);
+        props.add(SAMPLER_INTERVAL);
+        props.add(USERNAME);
+        props.add(PASSWORD);
+        props.add(PROP_SHIELD_LOCATION);
+        props.add(HOSTS);
+        props.add(PROP_SSL_CONTEXT_SERVICE);
+        props.add(CHARSET);
+
+        return Collections.unmodifiableList(props);
+    }
+
+    @Override
+    @OnEnabled
+    public void init(ControllerServiceInitializationContext context) throws InitializationException  {
+        super.init(context);
+        synchronized(this) {
+            try {
+                createElasticsearchClient(context);
+                createBulkProcessor(context);
+            }catch (Exception e){
+                throw new InitializationException(e);
+            }
+        }
+    }
+
+    /**
+     * Instantiate ElasticSearch Client. This should be called by subclasses' @OnScheduled method to create a client
+     * if one does not yet exist. If called when scheduled, closeClient() should be called by the subclasses' @OnStopped
+     * method so the client will be destroyed when the processor is stopped.
+     *
+     * @param context The context for this processor
+     * @throws ProcessException if an error occurs while creating an Elasticsearch client
+     */
+    protected void createElasticsearchClient(ControllerServiceInitializationContext context) throws ProcessException {
+        if (esClient != null) {
+            return;
+        }
+
+        try {
+            final String username = context.getPropertyValue(USERNAME).asString();
+            final String password = context.getPropertyValue(PASSWORD).asString();
+            final String hosts = context.getPropertyValue(HOSTS).asString();
+
+            esHosts = getEsHosts(hosts);
+
+            if (esHosts != null) {
+
+                RestClientBuilder builder = RestClient.builder(esHosts);
+
+                if (!StringUtils.isEmpty(username) && !StringUtils.isEmpty(password)) {
+                    final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                    credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+
+                    builder.setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
+                                @Override
+                                public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+                                    return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                                }
+                            });
+                }
+
+                esClient = new RestHighLevelClient(builder);
+            }
+
+        } catch (Exception e) {
+            getLogger().error("Failed to create Elasticsearch client due to {}", new Object[]{e}, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get the ElasticSearch hosts.
+     *
+     * @param hosts A comma-separated list of ElasticSearch hosts (host:port,host2:port2, etc.)
+     * @return List of HttpHost for the ES hosts
+     */
+    private HttpHost[]  getEsHosts(String hosts) {
+
+        if (hosts == null) {
+            return null;
+        }
+        final List<String> esList = Arrays.asList(hosts.split(","));
+        HttpHost[] esHosts = new HttpHost[esList.size()];
+        int indHost = 0;
+
+        for (String item : esList) {
+            String[] addresses = item.split(":");
+            final String hostName = addresses[0].trim();
+            final int port = Integer.parseInt(addresses[1].trim());
+
+            esHosts[indHost] = new HttpHost(hostName, port);
+            indHost++;
+        }
+        return esHosts;
+    }
+
+
+    protected void createBulkProcessor(ControllerServiceInitializationContext context)
+    {
+        if (bulkProcessor != null) {
+            return;
+        }
+
+        // create the bulk processor
+
+       BulkProcessor.Listener listener = new BulkProcessor.Listener() {
+            @Override
+            public void beforeBulk(long l, BulkRequest bulkRequest) {
+                getLogger().debug("Going to execute bulk [id:{}] composed of {} actions", new Object[]{l, bulkRequest.numberOfActions()});
+            }
+
+            @Override
+            public void afterBulk(long l, BulkRequest bulkRequest, BulkResponse bulkResponse) {
+                getLogger().debug("Executed bulk [id:{}] composed of {} actions", new Object[]{l, bulkRequest.numberOfActions()});
+                if (bulkResponse.hasFailures()) {
+                    getLogger().warn("There was failures while executing bulk [id:{}]," +
+                                    " done bulk request in {} ms with failure = {}",
+                            new Object[]{l, bulkResponse.getTook().getMillis(), bulkResponse.buildFailureMessage()});
+                    for (BulkItemResponse item : bulkResponse.getItems()) {
+                        if (item.isFailed()) {
+                            errors.put(item.getId(), item.getFailureMessage());
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void afterBulk(long l, BulkRequest bulkRequest, Throwable throwable) {
+                getLogger().error("something went wrong while bulk loading events to es : {}", new Object[]{throwable.getMessage()});
+            }
+
+        };
+
+        BiConsumer<BulkRequest, ActionListener<BulkResponse>> bulkConsumer = (request, bulkListener) -> esClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
+        bulkProcessor = BulkProcessor.builder(bulkConsumer, listener)
+                .setBulkActions(context.getPropertyValue(BATCH_SIZE).asInteger())
+                .setBulkSize(new ByteSizeValue(context.getPropertyValue(BULK_SIZE).asInteger(), ByteSizeUnit.MB))
+                .setFlushInterval(TimeValue.timeValueSeconds(context.getPropertyValue(FLUSH_INTERVAL).asInteger()))
+                .setConcurrentRequests(context.getPropertyValue(CONCURRENT_REQUESTS).asInteger())
+                .setBackoffPolicy(getBackOffPolicy(context))
+                .build();
+    }
+
+    /**
+     * set up BackoffPolicy
+     */
+    private BackoffPolicy getBackOffPolicy(ControllerServiceInitializationContext context)
+    {
+        BackoffPolicy backoffPolicy = BackoffPolicy.exponentialBackoff();
+        if (context.getPropertyValue(BULK_BACK_OFF_POLICY).getRawValue().equals(DEFAULT_EXPONENTIAL_BACKOFF_POLICY.getValue())) {
+            backoffPolicy = BackoffPolicy.exponentialBackoff();
+        } else if (context.getPropertyValue(BULK_BACK_OFF_POLICY).getRawValue().equals(EXPONENTIAL_BACKOFF_POLICY.getValue())) {
+            backoffPolicy = BackoffPolicy.exponentialBackoff(
+                    TimeValue.timeValueMillis(context.getPropertyValue(BULK_THROTTLING_DELAY).asLong()),
+                    context.getPropertyValue(BULK_RETRY_NUMBER).asInteger()
+            );
+        } else if (context.getPropertyValue(BULK_BACK_OFF_POLICY).getRawValue().equals(CONSTANT_BACKOFF_POLICY.getValue())) {
+            backoffPolicy = BackoffPolicy.constantBackoff(
+                    TimeValue.timeValueMillis(context.getPropertyValue(BULK_THROTTLING_DELAY).asLong()),
+                    context.getPropertyValue(BULK_RETRY_NUMBER).asInteger()
+            );
+        } else if (context.getPropertyValue(BULK_BACK_OFF_POLICY).getRawValue().equals(NO_BACKOFF_POLICY.getValue())) {
+            backoffPolicy = BackoffPolicy.noBackoff();
+        }
+        return backoffPolicy;
+    }
+
+
+    @Override
+    public void bulkFlush() throws DatastoreClientServiceException {
+        bulkProcessor.flush();
+    }
+
+    @Override
+    public void bulkPut(String docIndex, String docType, String document, Optional<String> OptionalId) {
+        // add it to the bulk,
+        IndexRequest request = new IndexRequest(docIndex, docType)
+                .source(document, XContentType.JSON)
+                .opType(IndexRequest.OpType.INDEX);
+
+        if(OptionalId.isPresent()){
+            request.id(OptionalId.get());
+        }
+
+        bulkProcessor.add(request);
+    }
+
+    @Override
+    public void bulkPut(String docIndex, String docType, Map<String, ?> document, Optional<String> OptionalId) {
+        // add it to the bulk
+        IndexRequest request = new IndexRequest(docIndex, docType)
+                .source(document)
+                .opType(IndexRequest.OpType.INDEX);
+
+        if(OptionalId.isPresent()){
+            request.id(OptionalId.get());
+        }
+
+        bulkProcessor.add(request);
+    }
+
+    @Override
+    public List<MultiGetResponseRecord> multiGet(List<MultiGetQueryRecord> multiGetQueryRecords) throws DatastoreClientServiceException {
+
+        List<MultiGetResponseRecord> multiGetResponseRecords = new ArrayList<>();
+
+        MultiGetRequest multiGetRequest = new MultiGetRequest();
+
+        for (MultiGetQueryRecord multiGetQueryRecord : multiGetQueryRecords)
+        {
+            String index = multiGetQueryRecord.getIndexName();
+            String type = multiGetQueryRecord.getTypeName();
+            List<String> documentIds = multiGetQueryRecord.getDocumentIds();
+            String[] fieldsToInclude = multiGetQueryRecord.getFieldsToInclude();
+            String[] fieldsToExclude = multiGetQueryRecord.getFieldsToExclude();
+            if ((fieldsToInclude != null && fieldsToInclude.length > 0) || (fieldsToExclude != null && fieldsToExclude.length > 0)) {
+                for (String documentId : documentIds) {
+                    MultiGetRequest.Item item = new MultiGetRequest.Item(index, type, documentId);
+                    item.fetchSourceContext(new FetchSourceContext(true, fieldsToInclude, fieldsToExclude));
+                    multiGetRequest.add(item);
+                }
+            } else {
+                for (String documentId : documentIds) {
+                    multiGetRequest.add(index, type, documentId);
+                }
+            }
+        }
+
+        MultiGetResponse multiGetItemResponses = null;
+        try {
+            multiGetItemResponses = esClient.mget(multiGetRequest, RequestOptions.DEFAULT);
+        } catch (Exception e) {
+            getLogger().error("MultiGet query failed : {}", new Object[]{e.getMessage()});
+        }
+
+        if (multiGetItemResponses != null) {
+            for (MultiGetItemResponse itemResponse : multiGetItemResponses) {
+                GetResponse response = itemResponse.getResponse();
+                if (response != null && response.isExists()) {
+                    Map<String,Object> responseMap = response.getSourceAsMap();
+                    Map<String,String> retrievedFields = new HashMap<>();
+                    responseMap.forEach((k,v) -> {if (v!=null) retrievedFields.put(k, v.toString());});
+                    multiGetResponseRecords.add(new MultiGetResponseRecord(response.getIndex(), response.getType(), response.getId(), retrievedFields));
+                }
+            }
+        }
+
+        return multiGetResponseRecords;
+    }
+
+    @Override
+    public boolean existsCollection(String indexName) throws DatastoreClientServiceException {
+        boolean exists;
+        try {
+            GetIndexRequest request = new GetIndexRequest();
+            request.indices(indexName);
+            exists = esClient.indices().exists(request, RequestOptions.DEFAULT);
+        }
+        catch (Exception e){
+            throw new DatastoreClientServiceException(e);
+        }
+        return exists;
+    }
+
+    @Override
+    public void refreshCollection(String indexName) throws DatastoreClientServiceException {
+        try {
+            RefreshRequest request = new RefreshRequest(indexName);
+            esClient.indices().refresh(request, RequestOptions.DEFAULT);
+        }
+        catch (Exception e){
+            throw new DatastoreClientServiceException(e);
+        }
+    }
+
+    @Override
+    public void saveSync(String indexName, String doctype, Map<String, Object> doc) throws Exception {
+        IndexRequest indexRequest = new IndexRequest(indexName, doctype).source(doc);
+        esClient.index(indexRequest, RequestOptions.DEFAULT);
+        refreshCollection(indexName);
+    }
+
+
+    @Override
+    public long countCollection(String indexName) throws DatastoreClientServiceException {
+        CountResponse countResponse;
+        try {
+            CountRequest countRequest = new CountRequest(indexName);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+            countRequest.source(searchSourceBuilder);
+            countResponse = esClient.count(countRequest, RequestOptions.DEFAULT);
+        }
+        catch (Exception e){
+            throw new DatastoreClientServiceException(e);
+        }
+        return countResponse.getCount();
+    }
+
+    @Override
+    public void createCollection(String indexName, int numShards, int numReplicas) throws DatastoreClientServiceException {
+        // Define the index itself
+        CreateIndexRequest request = new CreateIndexRequest(indexName);
+
+        request.settings(Settings.builder()
+                .put("index.number_of_shards", numShards)
+                .put("index.number_of_replicas", numReplicas)
+        );
+
+        try {
+            CreateIndexResponse rsp = esClient.indices().create(request, RequestOptions.DEFAULT);
+            if (!rsp.isAcknowledged()) {
+                throw new IOException("Elasticsearch index definition not acknowledged");
+            }
+            getLogger().info("Created index {}", new Object[]{indexName});
+        } catch (Exception e) {
+            getLogger().error("Failed to create ES index", e);
+            throw new DatastoreClientServiceException("Failed to create ES index", e);
+        }
+    }
+
+    @Override
+    public void dropCollection(String indexName) throws DatastoreClientServiceException {
+        try {
+            DeleteIndexRequest request = new DeleteIndexRequest(indexName);
+            getLogger().info("Delete index {}", new Object[]{indexName});
+            esClient.indices().delete(request, RequestOptions.DEFAULT);
+        } catch (Exception e) {
+            throw new DatastoreClientServiceException(String.format("Unable to delete index %s", indexName), e);
+        }
+    }
+
+    @Override
+    public void copyCollection(String reindexScrollTimeout, String srcIndex, String dstIndex) throws DatastoreClientServiceException {
+        try {
+
+            SearchRequest searchRequest = new SearchRequest(srcIndex);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+                .query(QueryBuilders.matchAllQuery())
+                .size(100);
+            searchRequest.source(searchSourceBuilder).scroll(reindexScrollTimeout).searchType(SearchType.QUERY_THEN_FETCH);
+            SearchResponse scrollResp = esClient.search(searchRequest, RequestOptions.DEFAULT);
+
+            AtomicBoolean failed = new AtomicBoolean(false);
+
+            // A user of a BulkProcessor just keeps adding requests to it, and the BulkProcessor itself decides when
+            // to send a request to the ES nodes, based on its configuration settings. Calls can be triggerd by number
+            // of queued requests, total size of queued requests, and time since previous request. The defaults for
+            // these settings are all sensible, so are not overridden here. The BulkProcessor has an internal threadpool
+            // which allows it to send multiple batches concurrently; the default is "1" meaning that a single completed
+            // batch can be sending in the background while a new batch is being built. When the non-active batch is
+            // "full", the add call blocks until the background batch completes.
+
+            while (true) {
+                if (scrollResp.getHits().getHits().length == 0) {
+                    // No more results
+                    break;
+                }
+
+                for (SearchHit hit : scrollResp.getHits()) {
+                    IndexRequest request = new IndexRequest(dstIndex, hit.getType(), hit.getId());
+                    Map<String, Object> source = hit.getSourceAsMap();
+                    request.source(source);
+                    bulkProcessor.add(request);
+                }
+
+                String scrollId = scrollResp.getScrollId();
+                SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
+                scrollRequest.scroll(reindexScrollTimeout);
+                scrollResp = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
+            }
+
+            getLogger().info("Reindex completed");
+        }
+        catch (Exception e){
+            throw new DatastoreClientServiceException(e);
+        }
+    }
+
+    @Override
+    public void createAlias(String indexName, String aliasName) throws DatastoreClientServiceException {
+        try {
+
+            IndicesAliasesRequest request = new IndicesAliasesRequest();
+            IndicesAliasesRequest.AliasActions aliasAction =
+                    new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.ADD)
+                            .index(indexName)
+                            .alias(aliasName);
+            request.addAliasAction(aliasAction);
+            AcknowledgedResponse rsp = esClient.indices().updateAliases(request, RequestOptions.DEFAULT);
+
+            if (!rsp.isAcknowledged()) {
+                throw new DatastoreClientServiceException(String.format(
+                        "Creation of elasticsearch alias '%s' for index '%s' not acknowledged.", aliasName, indexName));
+            }
+        } catch (DatastoreClientServiceException e) {
+            getLogger().error("Failed to create elasticsearch alias {} for index {}", new Object[]{aliasName, indexName, e});
+            throw e;
+        }
+        catch (Exception e){
+            String msg = String.format("Failed to create elasticsearch alias '%s' for index '%s'", aliasName, indexName);
+            throw new DatastoreClientServiceException(e);
+        }
+    }
+
+    @Override
+    public boolean putMapping(String indexName, String doctype, String mappingAsJsonString) throws DatastoreClientServiceException {
+        PutMappingRequest request = new PutMappingRequest(indexName);
+        request.type(doctype);
+        request.source(mappingAsJsonString, XContentType.JSON);
+
+        try {
+            AcknowledgedResponse rsp = esClient.indices().putMapping(request, RequestOptions.DEFAULT);
+            if (!rsp.isAcknowledged()) {
+                throw new DatastoreClientServiceException("Elasticsearch mapping definition not acknowledged");
+            }
+            return true;
+        } catch (Exception e) {
+            getLogger().error("Failed to load ES mapping {} for index {}", new Object[]{doctype, indexName, e});
+            // This is an error that can be fixed by providing alternative inputs so return boolean rather
+            // than throwing an exception.
+            return false;
+        }
+    }
+
+    @Override
+    public void bulkPut(String indexTypeName, Record record) throws DatastoreClientServiceException {
+
+        final List<String> indexType = Arrays.asList(indexTypeName.split(","));
+
+        if (indexType.size() == 2) {
+            String indexName = indexType.get(0);
+            String typeName = indexType.get(1);
+            this.bulkPut(indexName, typeName, ElasticsearchRecordConverter.convertToString(record), Optional.of(record.getId()));
+        }
+        else {
+            throw new DatastoreClientServiceException("The Elastic Search type name is missing. Please add at least default.type to the processor parameters");
+        }
+
+    }
+
+    @Override
+    public void put(String collectionName, Record record, boolean asynchronous) throws DatastoreClientServiceException {
+        throw new NotImplementedException("Not yet supported for ElasticSearch 7.x");
+    }
+
+    @Override
+    public void remove(String collectionName, Record record, boolean asynchronous) throws DatastoreClientServiceException {
+        throw new NotImplementedException("Not yet supported for ElasticSearch 7.x");
+    }
+
+    @Override
+    public Record get(String collectionName, Record record) throws DatastoreClientServiceException {
+        throw new NotImplementedException("Not yet supported for ElasticSearch 7.x");
+    }
+
+    @Override
+    public Collection<Record> query(String query) {
+        throw new NotImplementedException("Not yet supported for ElasticSearch 7.x");
+    }
+
+    @Override
+    public long queryCount(String query) {
+        throw new NotImplementedException("Not yet supported for ElasticSearch 7.x");
+    }
+
+    @Override
+    public String convertRecordToString(Record record) {
+        return ElasticsearchRecordConverter.convertToString(record);
+    }
+
+    @Override
+    public long searchNumberOfHits(String docIndex, String docType, String docName, String docValue) {
+
+        long numberOfHits;
+
+        try {
+            SearchRequest searchRequest = new SearchRequest(docIndex);
+
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+
+            sourceBuilder.query(QueryBuilders.termQuery(docName, docValue));
+            sourceBuilder.from(0);
+            sourceBuilder.size(60);
+            sourceBuilder.explain(false);
+
+            searchRequest.source(sourceBuilder);
+
+            SearchResponse searchResponse = esClient.search(searchRequest, RequestOptions.DEFAULT);
+            numberOfHits = searchResponse.getHits().getTotalHits().value;
+        }
+        catch (Exception e){
+            throw new DatastoreClientServiceException(e);
+        }
+
+        return numberOfHits;
+    }
+
+    @OnDisabled
+    public void shutdown() {
+        if (bulkProcessor != null) {
+            bulkProcessor.flush();
+            try {
+                if (!bulkProcessor.awaitClose(10, TimeUnit.SECONDS)) {
+                    getLogger().error("some request could not be send to es because of time out");
+                } else {
+                    getLogger().info("all requests have been submitted to es");
+                }
+            } catch (InterruptedException e) {
+                getLogger().error(e.getMessage());
+            }
+        }
+
+        if (esClient != null) {
+            getLogger().info("Closing ElasticSearch Client");
+            try {
+                esClient.close();
+            }
+            catch (Exception e){
+                throw new DatastoreClientServiceException(e);
+            }
+            esClient = null;
+        }
+    }
+
+
+}

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/java/com/hurence/logisland/service/elasticsearch/GeoPoint.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/java/com/hurence/logisland/service/elasticsearch/GeoPoint.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2019 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hurence.logisland.service.elasticsearch;
+
+public class GeoPoint {
+    double lat, lon;
+
+    public GeoPoint() {
+    }
+
+    public GeoPoint(double lat, double lon) {
+        this.lat = lat;
+        this.lon = lon;
+    }
+
+    public double getLat() {
+        return lat;
+    }
+
+    public void setLat(double lat) {
+        this.lat = lat;
+    }
+
+    public double getLon() {
+        return lon;
+    }
+
+    public void setLon(double lon) {
+        this.lon = lon;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "lat=" + lat +
+                ", lon=" + lon +
+                '}';
+    }
+}

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/resources/log4j2.xml
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="error">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/test/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverterTest.java
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/logisland-service-elasticsearch_7_x-client/src/test/java/com/hurence/logisland/service/elasticsearch/ElasticsearchRecordConverterTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2019 Hurence (support@hurence.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hurence.logisland.service.elasticsearch;
+
+import com.hurence.logisland.record.FieldType;
+import com.hurence.logisland.record.Record;
+import com.hurence.logisland.record.StandardRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ElasticsearchRecordConverterTest {
+
+    @Test
+    public void testBasics() throws Exception {
+
+        Record record = new StandardRecord("factory")
+                .setId("Modane")
+                .setStringField("address", "rue du Frejus")
+                .setField("latitude", FieldType.FLOAT, 45.4f)
+                .setField("longitude", FieldType.FLOAT, 41.4f);
+
+        String  convertedRecord = ElasticsearchRecordConverter.convertToString(record);
+
+        System.out.println(convertedRecord);
+
+        // Verify the index does not exist
+        Assert.assertEquals(true, convertedRecord.contains("location"));
+    }
+}

--- a/logisland-components/logisland-services/logisland-service-elasticsearch/pom.xml
+++ b/logisland-components/logisland-services/logisland-service-elasticsearch/pom.xml
@@ -36,6 +36,7 @@
         <module>logisland-service-elasticsearch_2_4_0-client</module>
         <module>logisland-service-elasticsearch_5_4_0-client</module>
         <module>logisland-service-elasticsearch_6_6_2-client</module>
+        <module>logisland-service-elasticsearch_7_x-client</module>
     </modules>
 
 

--- a/logisland-documentation/pom.xml
+++ b/logisland-documentation/pom.xml
@@ -122,6 +122,14 @@ THIS MODULE DOCUMENTATION DEPENDENCIES
             <groupId>com.hurence.logisland</groupId>
             <artifactId>logisland-service-elasticsearch_6_6_2-client</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hurence.logisland</groupId>
+            <artifactId>logisland-service-elasticsearch_7_x-client</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/logisland-documentation/pom.xml
+++ b/logisland-documentation/pom.xml
@@ -453,6 +453,8 @@ THIS MODULE DOCUMENTATION DEPENDENCIES
                                     <dependency>com.hurence.logisland:logisland-service-hbase_1_1_2-client</dependency>
                                     <dependency>com.hurence.logisland:logisland-service-elasticsearch_2_4_0-client</dependency>
                                     <dependency>com.hurence.logisland:logisland-service-elasticsearch_5_4_0-client</dependency>
+                                    <dependency>com.hurence.logisland:logisland-service-elasticsearch_6_6_2-client</dependency>
+                                    <dependency>com.hurence.logisland:logisland-service-elasticsearch_7_x-client</dependency>
                                     <dependency>com.hurence.logisland:logisland-service-redis</dependency>
                                     <dependency>com.hurence.logisland:logisland-service-mongodb-client</dependency>
                                     <dependency>com.hurence.logisland:logisland-service-cassandra-client</dependency>

--- a/logisland-documentation/user/components/services.rst
+++ b/logisland-documentation/user/components/services.rst
@@ -193,6 +193,104 @@ No additional information is provided
 
 ----------
 
+.. _com.hurence.logisland.service.elasticsearch.Elasticsearch_6_6_2_ClientService: 
+
+Elasticsearch_6_6_2_ClientService
+---------------------------------
+Implementation of ElasticsearchClientService for Elasticsearch 6.6.2.
+
+Module
+______
+com.hurence.logisland:logisland-service-elasticsearch_6_6_2-client:1.1.2
+
+Class
+_____
+com.hurence.logisland.service.elasticsearch.Elasticsearch_6_6_2_ClientService
+
+Tags
+____
+elasticsearch, client
+
+Properties
+__________
+In the list below, the names of required properties appear in **bold**. Any other properties (not in bold) are considered optional. The table also indicates any default values, and whether a property is considered "sensitive"..
+
+.. csv-table:: allowable-values
+   :header: "Name","Description","Allowable Values","Default Value","Sensitive","EL"
+   :widths: 20,60,30,20,10,10
+   :escape: \
+
+   "**backoff.policy**", "strategy for retrying to execute requests in bulkRequest", "noBackoff (when a request fail there won't be any retry.), constantBackoff (wait a fixed amount of time between retries, using user put retry number and throttling delay), exponentialBackoff (time waited between retries grow exponentially, using user put retry number and throttling delay), defaultExponentialBackoff (time waited between retries grow exponentially, using es default parameters)", "defaultExponentialBackoff", "false", "false"
+   "**throttling.delay**", "number of time we should wait between each retry (in milliseconds)", "", "500", "false", "false"
+   "**num.retry**", "number of time we should try to inject a bulk into es", "", "3", "false", "false"
+   "batch.size", "The preferred number of Records to setField to the database in a single transaction", "", "1000", "false", "false"
+   "bulk.size", "bulk size in MB", "", "5", "false", "false"
+   "flush.interval", "flush interval in sec", "", "5", "false", "false"
+   "concurrent.requests", "setConcurrentRequests", "", "2", "false", "false"
+   "**ping.timeout**", "The ping timeout used to determine when a node is unreachable. For example, 5s (5 seconds). If non-local recommended is 30s", "", "5s", "false", "false"
+   "**sampler.interval**", "How often to sample / ping the nodes listed and connected. For example, 5s (5 seconds). If non-local recommended is 30s.", "", "5s", "false", "false"
+   "username", "Username to access the Elasticsearch cluster", "", "null", "false", "false"
+   "password", "Password to access the Elasticsearch cluster", "", "null", "**true**", "false"
+   "shield.location", "Specifies the path to the JAR for the Elasticsearch Shield plugin. If the Elasticsearch cluster has been secured with the Shield plugin, then the Shield plugin JAR must also be available to this processor. Note: Do NOT place the Shield JAR into NiFi's lib/ directory, doing so will prevent the Shield plugin from being loaded.", "", "null", "false", "false"
+   "**hosts**", "ElasticSearch Hosts, which should be comma separated and colon for hostname/port host1:port,host2:port,....  For example testcluster:9300.", "", "null", "false", "false"
+   "ssl.context.service", "The SSL Context Service used to provide client certificate information for TLS/SSL connections. This service only applies if the Shield plugin is available.", "", "null", "false", "false"
+   "**charset**", "Specifies the character set of the document data.", "", "UTF-8", "false", "false"
+
+Extra informations
+__________________
+No additional information is provided
+
+----------
+
+.. _com.hurence.logisland.service.elasticsearch.Elasticsearch_7_x_ClientService: 
+
+Elasticsearch_7_x_ClientService
+-------------------------------
+Implementation of ElasticsearchClientService for ElasticSearch 7.x. Note that although Elasticsearch 7.x still accepts type information, this implementation will ignore any type usage and will only work at the index level to be already compliant with the ElasticSearch 8.x version that will completely remove type usage.
+
+Module
+______
+com.hurence.logisland:logisland-service-elasticsearch_7_x-client:1.1.2
+
+Class
+_____
+com.hurence.logisland.service.elasticsearch.Elasticsearch_7_x_ClientService
+
+Tags
+____
+elasticsearch, client
+
+Properties
+__________
+In the list below, the names of required properties appear in **bold**. Any other properties (not in bold) are considered optional. The table also indicates any default values, and whether a property is considered "sensitive"..
+
+.. csv-table:: allowable-values
+   :header: "Name","Description","Allowable Values","Default Value","Sensitive","EL"
+   :widths: 20,60,30,20,10,10
+   :escape: \
+
+   "**backoff.policy**", "strategy for retrying to execute requests in bulkRequest", "noBackoff (when a request fail there won't be any retry.), constantBackoff (wait a fixed amount of time between retries, using user put retry number and throttling delay), exponentialBackoff (time waited between retries grow exponentially, using user put retry number and throttling delay), defaultExponentialBackoff (time waited between retries grow exponentially, using es default parameters)", "defaultExponentialBackoff", "false", "false"
+   "**throttling.delay**", "number of time we should wait between each retry (in milliseconds)", "", "500", "false", "false"
+   "**num.retry**", "number of time we should try to inject a bulk into es", "", "3", "false", "false"
+   "batch.size", "The preferred number of Records to setField to the database in a single transaction", "", "1000", "false", "false"
+   "bulk.size", "bulk size in MB", "", "5", "false", "false"
+   "flush.interval", "flush interval in sec", "", "5", "false", "false"
+   "concurrent.requests", "setConcurrentRequests", "", "2", "false", "false"
+   "**ping.timeout**", "The ping timeout used to determine when a node is unreachable. For example, 5s (5 seconds). If non-local recommended is 30s", "", "5s", "false", "false"
+   "**sampler.interval**", "How often to sample / ping the nodes listed and connected. For example, 5s (5 seconds). If non-local recommended is 30s.", "", "5s", "false", "false"
+   "username", "Username to access the Elasticsearch cluster", "", "null", "false", "false"
+   "password", "Password to access the Elasticsearch cluster", "", "null", "**true**", "false"
+   "shield.location", "Specifies the path to the JAR for the Elasticsearch Shield plugin. If the Elasticsearch cluster has been secured with the Shield plugin, then the Shield plugin JAR must also be available to this processor. Note: Do NOT place the Shield JAR into NiFi's lib/ directory, doing so will prevent the Shield plugin from being loaded.", "", "null", "false", "false"
+   "**hosts**", "ElasticSearch Hosts, which should be comma separated and colon for hostname/port host1:port,host2:port,....  For example testcluster:9300.", "", "null", "false", "false"
+   "ssl.context.service", "The SSL Context Service used to provide client certificate information for TLS/SSL connections. This service only applies if the Shield plugin is available.", "", "null", "false", "false"
+   "**charset**", "Specifies the character set of the document data.", "", "UTF-8", "false", "false"
+
+Extra informations
+__________________
+No additional information is provided
+
+----------
+
 .. _com.hurence.logisland.service.hbase.HBase_1_1_2_ClientService: 
 
 HBase_1_1_2_ClientService


### PR DESCRIPTION
This introduces the Elasticsearch 7.x service (#479)

Warning: type usage is now ignored.

Also it seems 7 client is compatible with 7.x servers so I decided to remove the hardcoded full verison in naming so that one understand that it should fit 7.x. I think that it is a good practise from now. However, the used ES client version is 7.1.1.

More info on types and how I used them:

In ES7, types are still present if needed but will be deprecated in 8.
See https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html#_schedule_for_removal_of_mapping_types

I took the decision however to make 7.x implem ignore types. ES Dataservice API still uses type for backward compatibility purpose, but when talking to a 7.x service, type is ignored.

So any existing components using the ES Service API (for instance in webanalytics suite) can still use types so that when configuring an older release of ES prior to 7, the types are getting created/used, but when talking to ES7 service, no types are created/used. They are simply ignored and you can pass null values or types in the ES Datastore API.

A default type named '_doc' is visible when getting documents from the search API (ES7 behaviour).

Any deprecated call in ES client has been avoided. Reindex API seems now no more an experimental feature so really using ES reindex API also instead of internal search and bulkput.
