### PR TITLE
Feature/logisland 587 support for structured stream checkpointing on azure filesystem

### DIFF
--- a/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_3/pom.xml
+++ b/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_3/pom.xml
@@ -189,7 +189,9 @@ http://www.w3.org/2001/XMLSchema-instance ">
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/license/**</exclude>
-                                        <exclude>META-INF/*</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
                                         <exclude>META-INF/maven/**</exclude>
                                         <exclude>LICENSE</exclude>
                                         <exclude>NOTICE</exclude>

--- a/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/pom.xml
+++ b/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/pom.xml
@@ -24,6 +24,8 @@ http://www.w3.org/2001/XMLSchema-instance ">
         <scala.version>2.11.8</scala.version>
         <jackson.version>2.6.6</jackson.version>
         <eventhubs.version>2.3.14.1</eventhubs.version>
+        <hadoop-azure.version>2.7.0</hadoop-azure.version>
+        <hadoop-common.version>2.7.0</hadoop-common.version>
     </properties>
 
 
@@ -388,6 +390,7 @@ http://www.w3.org/2001/XMLSchema-instance ">
             <version>5.1.3.RELEASE</version>
         </dependency>
 
+        <!-- Allow to interact with azure eventhub -->
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-eventhubs-spark_${scala.binary.version}</artifactId>
@@ -400,6 +403,19 @@ http://www.w3.org/2001/XMLSchema-instance ">
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- hadoop-azure and  hadoop-common allow to interact with azure storage (checkpointing...) -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-azure</artifactId>
+            <version>${hadoop-azure.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop-common.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/structured/StructuredStream.scala
+++ b/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/structured/StructuredStream.scala
@@ -44,6 +44,7 @@ class StructuredStream extends AbstractRecordStream with SparkRecordStream {
     descriptors.add(WRITE_STREAM_SERVICE_PROVIDER)
     descriptors.add(GROUP_BY_FIELDS)
     descriptors.add(SPARK_BASE_CHECKPOINT_PATH)
+    descriptors.add(SPARK_SQL_SHUFFLE_PARTITIONS)
 //    descriptors.add(STATE_TIMEOUT_DURATION_MS)
 //    descriptors.add(STATE_TIMEOUT_DURATION_MS)
 //    descriptors.add(STATEFULL_OUTPUT_MODE)
@@ -88,7 +89,8 @@ class StructuredStream extends AbstractRecordStream with SparkRecordStream {
       val pipelineMetricPrefix = context.getIdentifier /*+ ".partition" + partitionId*/ + "."
       val pipelineTimerContext = UserMetricsSystem.timer(pipelineMetricPrefix + "Pipeline.processing_time_ms").time()
 
-      sparkSession.sqlContext.setConf("spark.sql.shuffle.partitions", "4")//TODO make this configurable
+      sparkSession.sqlContext.setConf("spark.sql.shuffle.partitions",
+        context.getPropertyValue(SPARK_SQL_SHUFFLE_PARTITIONS).asString())
 
       //TODO Je pense que ces deux ligne ne servent a rien
       val controllerServiceLookup = sparkStreamContext.broadCastedControllerServiceLookupSink.value.getControllerServiceLookup()
@@ -266,5 +268,13 @@ object StructuredStream {
     .required(false)
     .defaultValue("checkpoints")
     .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+    .build;
+
+  val SPARK_SQL_SHUFFLE_PARTITIONS: PropertyDescriptor = new PropertyDescriptor.Builder()
+    .name("spark.sql.shuffle.partitions")
+    .description("Regular spark.sql.shuffle.partitions. Defaults to 200")
+    .required(false)
+    .defaultValue("200")
+    .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
     .build;
 }

--- a/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/structured/StructuredStream.scala
+++ b/logisland-core/logisland-engines/logisland-engine-spark_2_X/logisland-engine-spark_2_common/src/main/scala/com/hurence/logisland/stream/spark/structured/StructuredStream.scala
@@ -257,11 +257,14 @@ object StructuredStream {
 
   val SPARK_BASE_CHECKPOINT_PATH: PropertyDescriptor = new PropertyDescriptor.Builder()
     .name("spark.base.checkpoint.path")
-    .description("Path to store all checkpoint for all sink, they will b stored in" +
-      " ${spark.base.checkpoint.path}/${stream_id}/${service_id}")
+    .description("Path to store all checkpoint for all sink, they will be stored in" +
+      " ${spark.base.checkpoint.path}/${stream_id}/${service_id}. If using for instance azure filesystem to" +
+      " checkpoint, then use KafkaStreamProcessingEngine spark.custom.config.xxx property like to set filesystem" +
+      " credentials. Suppose you set something like `spark.base.checkpoint.path: wasbs://<myContainer>@<myStorageAccount>.blob.core.windows.net/spark-checkpointing`" +
+      " in StructuredStream configuration, then you can set the matching SAS key under the root KafkaStreamProcessingEngine configuration" +
+      " with something like `spark.custom.config.fs.azure.account.key.<myStorageAccount>.blob.core.windows.net: +H5IuOtsebY7fO6QyyntmlRLe3G8Rv0jcye6kzE2Wz4NrU3IdB4Q8ocJY2ScY9cQrJNXxUg2WbYJPndMuQWUCQ==`")
     .required(false)
     .defaultValue("checkpoints")
     .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
     .build;
-
 }


### PR DESCRIPTION
Save in 1.4.0 branch:
- additions to support azure checkpointing (see #587 for needed workaround)
- Replaced hardcoded spark.sql.shuffle.partitions option with configuration property in StructuredStream